### PR TITLE
Cleanup directories on destination

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,35 @@
+name: integration-test
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  integration-test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Java 19
+        uses: actions/setup-java@v3
+        with:
+          distribution: corretto
+          java-version: 19
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: integration Test
+        run: ./gradlew projects clean integrationTest --no-daemon --refresh-dependencies
+
+      - name: Upload coverage to Codecov (Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v3
+        with:
+          flags: integration-tests
+          fail_ci_if_error: false

--- a/.github/workflows/performance-test.yml
+++ b/.github/workflows/performance-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # file-backup
 
 [![build](https://github.com/will-molloy/file-backup/workflows/build/badge.svg?branch=main&event=push)](https://github.com/will-molloy/file-backup/actions?query=workflow%3Abuild)
+[![integration-test](https://github.com/will-molloy/file-backup/workflows/integration-test/badge.svg?branch=main&event=push)](https://github.com/will-molloy/file-backup/actions?query=workflow%3Aintegration-test)
 [![performance-test](https://github.com/will-molloy/file-backup/workflows/performance-test/badge.svg?branch=main&event=push)](https://github.com/will-molloy/file-backup/actions?query=workflow%3Aperformance-test)
 [![docker](https://github.com/will-molloy/file-backup/workflows/docker/badge.svg?branch=main&event=push)](https://github.com/will-molloy/file-backup/actions?query=workflow%3Adocker)
 [![codecov](https://codecov.io/gh/will-molloy/file-backup/branch/main/graph/badge.svg)](https://codecov.io/gh/will-molloy/file-backup)
@@ -14,7 +15,7 @@
 ## Build and test
 
 ```bash
-./gradlew spotlessApply build performanceTest
+./gradlew spotlessApply build integrationTest performanceTest
 ```
 
 ## Usage

--- a/build.gradle
+++ b/build.gradle
@@ -105,8 +105,10 @@ subprojects {
   // Integration test support
   apply plugin: 'org.unbroken-dome.test-sets'
   testSets {
+    integrationTest
     performanceTest
   }
+  integrationTest.finalizedBy jacocoPerformanceTestReport
   performanceTest.finalizedBy jacocoPerformanceTestReport
 
   // enable preview features

--- a/file-backup-core/src/main/java/com/willmolloy/backup/Backup.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/Backup.java
@@ -52,8 +52,8 @@ public interface Backup<
     /** File size in bytes. */
     long size();
 
-    /** {@code true} if file. {@code false} if directory. */
-    boolean isRegularFile();
+    /** {@code true} if directory. {@code false} if file. */
+    boolean isDirectory();
 
     /**
      * {@code true} if the {@code other} file can be considered the same.

--- a/file-backup-core/src/main/java/com/willmolloy/backup/Backup.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/Backup.java
@@ -9,8 +9,7 @@ import java.util.Map;
  * @param <DestinationT> destination location type
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public interface Backup<
-    SourceT extends Backup.Location<?>, DestinationT extends Backup.Location<?>> {
+public interface Backup<SourceT extends Backup.Location, DestinationT extends Backup.Location> {
 
   SourceT source();
 
@@ -31,41 +30,41 @@ public interface Backup<
    */
   boolean delete(String key);
 
-  /**
-   * Backup location (source or destination).
-   *
-   * @param <FileT> type of file stored on this location
-   */
-  interface Location<FileT extends File> {
+  /** Backup location (source or destination). */
+  interface Location {
 
     /**
-     * Scans the location.
+     * Scans the location's file tree.
      *
-     * @return Map of relativized file path (key) to file.
+     * @return Map of (relativized) paths to nodes.
      */
-    Map<String, FileT> scan();
+    Map<String, Node> scan();
   }
 
-  /** Backup file. */
-  interface File {
+  /** Represents a node in a locations file tree. Either a file or directory. */
+  sealed interface Node permits Node.File, Node.Directory {
 
-    /** File size in bytes. */
-    long size();
+    /** File. */
+    non-sealed interface File extends Node {
 
-    /** {@code true} if directory. {@code false} if file. */
-    boolean isDirectory();
+      /** File size in bytes. */
+      long size();
 
-    /**
-     * {@code true} if the {@code other} file can be considered the same.
-     *
-     * @apiNote Used to determine if a file requires updating.
-     * @implNote The default implementation just looks at file size.
-     */
-    // for s3; considered last-modified, but it's really object-creation time.
-    // also considered e-tag, but it's calculated differently for large (> 16MB) files.
-    // file size is good enough?
-    default boolean same(File other) {
-      return size() == other.size();
+      /**
+       * {@code true} if the {@code other} file can be considered the same.
+       *
+       * @apiNote Used to determine if a file requires updating.
+       * @implNote The default implementation just looks at file size.
+       */
+      // for s3; considered last-modified, but it's really object-creation time.
+      // also considered e-tag, but it's calculated differently for large (> 16MB) files.
+      // file size is good enough?
+      default boolean same(File other) {
+        return size() == other.size();
+      }
     }
+
+    /** Directory. */
+    non-sealed interface Directory extends Node {}
   }
 }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/Backup.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/Backup.java
@@ -52,6 +52,9 @@ public interface Backup<
     /** File size in bytes. */
     long size();
 
+    /** {@code true} if file. {@code false} if directory. */
+    boolean isRegularFile();
+
     /**
      * {@code true} if the {@code other} file can be considered the same.
      *

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -2,9 +2,8 @@ package com.willmolloy.backup;
 
 import static com.willmolloy.backup.util.Preconditions.require;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Predicate.not;
 
-import com.willmolloy.backup.Backup.File;
+import com.willmolloy.backup.Backup.Node;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.text.NumberFormat;
 import java.time.Duration;
@@ -17,6 +16,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -66,34 +66,31 @@ public final class BackupRunner {
     try (ExecutorService threadPool =
         Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("worker-", 1).factory())) {
 
-      Map<String, ? extends File> sourceFiles = scanWithLog(backup.source()::scan, "source");
-      Map<String, ? extends File> destFiles =
-          scanWithLog(backup.destination()::scan, "destination");
+      Map<String, Node> sourceNodes = scanWithLog(backup.source()::scan, "source");
+      Map<String, Node> destNodes = scanWithLog(backup.destination()::scan, "destination");
 
-      sourceFiles.forEach(
-          (key, sourceFile) -> {
+      sourceNodes.forEach(
+          (key, sourceNode) -> {
             // limit to files only for now
             // TODO what about backing up empty dirs (i.e. leaves)?
             //  Would require expensive IO call to test 'is empty dir'...
-            if (sourceFile.isDirectory()) {
-              return;
-            }
-
-            File destFile = destFiles.get(key);
-            if (destFile == null) {
-              threadPool.submit(() -> create(key, sourceFile));
-            } else if (!sourceFile.same(destFile)) {
-              threadPool.submit(() -> update(key, sourceFile, destFile));
-            } else {
-              sameCount.incrementAndGet();
+            if (sourceNode instanceof Node.File sourceFile) {
+              Node destNode = destNodes.get(key);
+              if (destNode == null || destNode instanceof Node.Directory) {
+                threadPool.submit(() -> create(key, sourceFile));
+              } else if (destNode instanceof Node.File destFile && !sourceFile.same(destFile)) {
+                threadPool.submit(() -> update(key, sourceFile, destFile));
+              } else {
+                sameCount.incrementAndGet();
+              }
             }
           });
 
       // for dest we need to attempt deletion of every path, including directories
       // otherwise empty dirs are left on destination
-      destFiles.forEach(
+      destNodes.forEach(
           (key, destFile) -> {
-            if (!sourceFiles.containsKey(key)) {
+            if (!sourceNodes.containsKey(key)) {
               threadPool.submit(() -> delete(key, destFile));
             }
           });
@@ -101,14 +98,16 @@ public final class BackupRunner {
     return getAndLogStats(runStartNanos);
   }
 
-  private Map<String, ? extends File> scanWithLog(
-      Supplier<Map<String, ? extends File>> scan, String locationForLog) {
+  private Map<String, Node> scanWithLog(Supplier<Map<String, Node>> scan, String locationForLog) {
     long scanStartNanos = System.nanoTime();
 
-    Map<String, ? extends File> paths = scan.get();
+    Map<String, Node> nodes = scan.get();
 
-    List<? extends File> files = paths.values().stream().filter(not(File::isDirectory)).toList();
-    long sizeMB = files.stream().mapToLong(File::size).sum() / MEGA;
+    List<Node.File> files =
+        nodes.values().stream()
+            .flatMap(node -> node instanceof Node.File file ? Stream.of(file) : Stream.empty())
+            .toList();
+    long sizeMB = files.stream().mapToLong(Node.File::size).sum() / MEGA;
     log.info(
         "Scanned {} in: {}. {} files. {}MB",
         locationForLog,
@@ -116,10 +115,10 @@ public final class BackupRunner {
         NUMBER_FORMAT.format(files.size()),
         NUMBER_FORMAT.format(sizeMB));
 
-    return paths;
+    return nodes;
   }
 
-  private void create(String key, File sourceFile) {
+  private void create(String key, Node.File sourceFile) {
     if (backup.put(key)) {
       createCount.incrementAndGet();
       bytesAdded.addAndGet(sourceFile.size());
@@ -128,7 +127,7 @@ public final class BackupRunner {
     }
   }
 
-  private void update(String key, File sourceFile, File destFile) {
+  private void update(String key, Node.File sourceFile, Node.File destFile) {
     if (backup.put(key)) {
       updateCount.incrementAndGet();
       bytesAdded.addAndGet(sourceFile.size());
@@ -138,9 +137,9 @@ public final class BackupRunner {
     }
   }
 
-  private void delete(String key, File destFile) {
+  private void delete(String key, Node destNode) {
     if (backup.delete(key)) {
-      if (!destFile.isDirectory()) {
+      if (destNode instanceof Node.File destFile) {
         deleteCount.incrementAndGet();
         bytesRemoved.addAndGet(destFile.size());
       }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -7,6 +7,7 @@ import com.willmolloy.backup.Backup.File;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.text.NumberFormat;
 import java.time.Duration;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -70,6 +71,13 @@ public final class BackupRunner {
 
       sourceFiles.forEach(
           (key, sourceFile) -> {
+            // limit to files only for now
+            // TODO what about backing up empty dirs (i.e. leaves)?
+            //  Would require expensive IO call to test 'is empty dir'...
+            if (!sourceFile.isRegularFile()) {
+              return;
+            }
+
             File destFile = destFiles.get(key);
             if (destFile == null) {
               threadPool.submit(() -> create(key, sourceFile));
@@ -80,6 +88,8 @@ public final class BackupRunner {
             }
           });
 
+      // for dest we need to attempt deletion of every path, including directories
+      // otherwise empty dirs are left on destination
       destFiles.forEach(
           (key, destFile) -> {
             if (!sourceFiles.containsKey(key)) {
@@ -93,18 +103,23 @@ public final class BackupRunner {
   private Map<String, ? extends File> scanWithLog(
       Supplier<Map<String, ? extends File>> scan, String locationForLog) {
     long scanStartNanos = System.nanoTime();
-    Map<String, ? extends File> files = scan.get();
-    long sizeMB = files.values().stream().mapToLong(File::size).sum() / MEGA;
+
+    Map<String, ? extends File> paths = scan.get();
+
+    List<? extends File> files = paths.values().stream().filter(File::isRegularFile).toList();
+    long sizeMB = files.stream().mapToLong(File::size).sum() / MEGA;
     log.info(
         "Scanned {} in: {}. {} files. {}MB",
         locationForLog,
         elapsed(scanStartNanos),
         NUMBER_FORMAT.format(files.size()),
         NUMBER_FORMAT.format(sizeMB));
-    return files;
+
+    return paths;
   }
 
   private void create(String key, File sourceFile) {
+    require(sourceFile.isRegularFile(), "create requires file");
     if (backup.put(key)) {
       createCount.incrementAndGet();
       bytesAdded.addAndGet(sourceFile.size());
@@ -114,6 +129,7 @@ public final class BackupRunner {
   }
 
   private void update(String key, File sourceFile, File destFile) {
+    require(sourceFile.isRegularFile(), "update requires file");
     if (backup.put(key)) {
       updateCount.incrementAndGet();
       bytesAdded.addAndGet(sourceFile.size());
@@ -125,8 +141,10 @@ public final class BackupRunner {
 
   private void delete(String key, File destFile) {
     if (backup.delete(key)) {
-      deleteCount.incrementAndGet();
-      bytesRemoved.addAndGet(destFile.size());
+      if (destFile.isRegularFile()) {
+        deleteCount.incrementAndGet();
+        bytesRemoved.addAndGet(destFile.size());
+      }
     } else {
       failedDeleteCount.incrementAndGet();
     }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -71,17 +71,21 @@ public final class BackupRunner {
 
       sourceNodes.forEach(
           (key, sourceNode) -> {
-            // limit to files only for now
-            // TODO what about backing up empty dirs (i.e. leaves)?
-            //  Would require expensive IO call to test 'is empty dir'...
-            if (sourceNode instanceof Node.File sourceFile) {
-              Node destNode = destNodes.get(key);
-              if (destNode == null || destNode instanceof Node.Directory) {
-                threadPool.submit(() -> create(key, sourceFile));
-              } else if (destNode instanceof Node.File destFile && !sourceFile.same(destFile)) {
-                threadPool.submit(() -> update(key, sourceFile, destFile));
-              } else {
-                sameCount.incrementAndGet();
+            switch (sourceNode) {
+              case Node.File sourceFile -> {
+                Node destNode = destNodes.get(key);
+                if (destNode == null || destNode instanceof Node.Directory) {
+                  threadPool.submit(() -> create(key, sourceFile));
+                } else if (destNode instanceof Node.File destFile && !sourceFile.same(destFile)) {
+                  threadPool.submit(() -> update(key, sourceFile, destFile));
+                } else {
+                  sameCount.incrementAndGet();
+                }
+              }
+              case Node.Directory sourceDir -> {
+                // limit to files only for now
+                // TODO what about backing up empty dirs (i.e. leaves)?
+                //  Would require expensive IO call to test 'is empty dir'...
               }
             }
           });

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -2,6 +2,7 @@ package com.willmolloy.backup;
 
 import static com.willmolloy.backup.util.Preconditions.require;
 import static java.util.Objects.requireNonNull;
+import static java.util.function.Predicate.not;
 
 import com.willmolloy.backup.Backup.File;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -74,7 +75,7 @@ public final class BackupRunner {
             // limit to files only for now
             // TODO what about backing up empty dirs (i.e. leaves)?
             //  Would require expensive IO call to test 'is empty dir'...
-            if (!sourceFile.isRegularFile()) {
+            if (sourceFile.isDirectory()) {
               return;
             }
 
@@ -106,7 +107,7 @@ public final class BackupRunner {
 
     Map<String, ? extends File> paths = scan.get();
 
-    List<? extends File> files = paths.values().stream().filter(File::isRegularFile).toList();
+    List<? extends File> files = paths.values().stream().filter(not(File::isDirectory)).toList();
     long sizeMB = files.stream().mapToLong(File::size).sum() / MEGA;
     log.info(
         "Scanned {} in: {}. {} files. {}MB",
@@ -119,7 +120,6 @@ public final class BackupRunner {
   }
 
   private void create(String key, File sourceFile) {
-    require(sourceFile.isRegularFile(), "create requires file");
     if (backup.put(key)) {
       createCount.incrementAndGet();
       bytesAdded.addAndGet(sourceFile.size());
@@ -129,7 +129,6 @@ public final class BackupRunner {
   }
 
   private void update(String key, File sourceFile, File destFile) {
-    require(sourceFile.isRegularFile(), "update requires file");
     if (backup.put(key)) {
       updateCount.incrementAndGet();
       bytesAdded.addAndGet(sourceFile.size());
@@ -141,7 +140,7 @@ public final class BackupRunner {
 
   private void delete(String key, File destFile) {
     if (backup.delete(key)) {
-      if (destFile.isRegularFile()) {
+      if (!destFile.isDirectory()) {
         deleteCount.incrementAndGet();
         bytesRemoved.addAndGet(destFile.size());
       }

--- a/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
@@ -2,13 +2,14 @@ package com.willmolloy.backup;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import com.willmolloy.backup.Backup.File;
 import com.willmolloy.backup.Backup.Location;
+import com.willmolloy.backup.Backup.Node;
 import com.willmolloy.backup.BackupRunner.ErrorStatistics;
 import com.willmolloy.backup.BackupRunner.OverallStatistics;
 import com.willmolloy.backup.BackupRunner.Statistics;
@@ -30,11 +31,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class BackupRunnerTest {
 
-  @Mock private File mockSourceFile;
-  @Mock private File mockDestinationFile;
-  @Mock private Location<File> mockSource;
-  @Mock private Location<File> mockDestination;
-  @Mock private Backup<Location<File>, Location<File>> mockBackup;
+  @Mock private Location mockSource;
+  @Mock private Location mockDestination;
+  @Mock private Backup<Location, Location> mockBackup;
 
   @BeforeEach
   void setUp() {
@@ -54,7 +53,7 @@ class BackupRunnerTest {
   @Test
   void whenFileOnSourceAndNotDestination_createsFileOnDestination() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
+    when(mockSource.scan()).thenReturn(Map.of("A", mock(Node.File.class)));
     when(mockDestination.scan()).thenReturn(Map.of());
     when(mockBackup.put(any())).thenReturn(true);
 
@@ -71,8 +70,7 @@ class BackupRunnerTest {
   @Test
   void whenDirectoryOnSourceAndNotDestination_skipsCreate() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
-    when(mockSourceFile.isDirectory()).thenReturn(true);
+    when(mockSource.scan()).thenReturn(Map.of("A", mock(Node.Directory.class)));
     when(mockDestination.scan()).thenReturn(Map.of());
 
     // When
@@ -88,10 +86,12 @@ class BackupRunnerTest {
   @Test
   void whenFileOnSourceAndDestination_andNotSame_updatesFileOnDestination() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
+    Node.File sourceFile = mock(Node.File.class);
+    when(mockSource.scan()).thenReturn(Map.of("A", sourceFile));
+    Node.File destFile = mock(Node.File.class);
+    when(mockDestination.scan()).thenReturn(Map.of("A", destFile));
     when(mockBackup.put(any())).thenReturn(true);
-    when(mockSourceFile.same(mockDestinationFile)).thenReturn(false);
+    when(sourceFile.same(destFile)).thenReturn(false);
 
     // When
     OverallStatistics statistics = BackupRunner.run(mockBackup);
@@ -106,9 +106,11 @@ class BackupRunnerTest {
   @Test
   void whenFileOnSourceAndDestination_andSame_skipsUpdate() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
-    when(mockSourceFile.same(mockDestinationFile)).thenReturn(true);
+    Node.File sourceFile = mock(Node.File.class);
+    when(mockSource.scan()).thenReturn(Map.of("A", sourceFile));
+    Node.File destFile = mock(Node.File.class);
+    when(mockDestination.scan()).thenReturn(Map.of("A", destFile));
+    when(sourceFile.same(destFile)).thenReturn(true);
 
     // When
     OverallStatistics statistics = BackupRunner.run(mockBackup);
@@ -123,10 +125,8 @@ class BackupRunnerTest {
   @Test
   void whenDirectoryOnSourceAndDestination_skipsUpdate() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
-    when(mockSourceFile.isDirectory()).thenReturn(true);
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
-    when(mockDestinationFile.isDirectory()).thenReturn(true);
+    when(mockSource.scan()).thenReturn(Map.of("A", mock(Node.Directory.class)));
+    when(mockDestination.scan()).thenReturn(Map.of("A", mock(Node.Directory.class)));
 
     // When
     OverallStatistics statistics = BackupRunner.run(mockBackup);
@@ -142,7 +142,7 @@ class BackupRunnerTest {
   void whenFileOnDestinationAndNotSource_deletesFileFromDestination() {
     // Given
     when(mockSource.scan()).thenReturn(Map.of());
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
+    when(mockDestination.scan()).thenReturn(Map.of("A", mock(Node.File.class)));
     when(mockBackup.delete(any())).thenReturn(true);
 
     // When
@@ -158,9 +158,11 @@ class BackupRunnerTest {
   @Test
   void whenFileOnDestinationAndSource_skipsDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
-    when(mockSourceFile.same(mockDestinationFile)).thenReturn(true);
+    Node.File sourceFile = mock(Node.File.class);
+    when(mockSource.scan()).thenReturn(Map.of("A", sourceFile));
+    Node.File destFile = mock(Node.File.class);
+    when(mockDestination.scan()).thenReturn(Map.of("A", destFile));
+    when(sourceFile.same(destFile)).thenReturn(true);
 
     // When
     OverallStatistics statistics = BackupRunner.run(mockBackup);
@@ -176,8 +178,7 @@ class BackupRunnerTest {
   void whenDirectoryOnDestinationAndNotSource_deletesDirectoryFromDestination() {
     // Given
     when(mockSource.scan()).thenReturn(Map.of());
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
-    when(mockDestinationFile.isDirectory()).thenReturn(true);
+    when(mockDestination.scan()).thenReturn(Map.of("A", mock(Node.Directory.class)));
     when(mockBackup.delete(any())).thenReturn(true);
 
     // When
@@ -193,10 +194,8 @@ class BackupRunnerTest {
   @Test
   void whenDirectoryOnDestinationAndSource_skipsDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
-    when(mockSourceFile.isDirectory()).thenReturn(true);
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
-    when(mockDestinationFile.isDirectory()).thenReturn(true);
+    when(mockSource.scan()).thenReturn(Map.of("A", mock(Node.Directory.class)));
+    when(mockDestination.scan()).thenReturn(Map.of("A", mock(Node.Directory.class)));
 
     // When
     OverallStatistics statistics = BackupRunner.run(mockBackup);
@@ -211,7 +210,7 @@ class BackupRunnerTest {
   @Test
   void whenCreateFails_countsFailedCreate() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
+    when(mockSource.scan()).thenReturn(Map.of("A", mock(Node.File.class)));
     when(mockDestination.scan()).thenReturn(Map.of());
     when(mockBackup.put(any())).thenReturn(false);
 
@@ -228,8 +227,8 @@ class BackupRunnerTest {
   @Test
   void whenUpdateFails_countsFailedUpdate() {
     // Given
-    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
+    when(mockSource.scan()).thenReturn(Map.of("A", mock(Node.File.class)));
+    when(mockDestination.scan()).thenReturn(Map.of("A", mock(Node.File.class)));
     when(mockBackup.put(any())).thenReturn(false);
 
     // When
@@ -247,8 +246,8 @@ class BackupRunnerTest {
   void whenDeleteFails_countsFailedDelete(boolean isDirectory) {
     // Given
     when(mockSource.scan()).thenReturn(Map.of());
-    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
-    when(mockDestinationFile.isDirectory()).thenReturn(isDirectory);
+    when(mockDestination.scan())
+        .thenReturn(Map.of("A", isDirectory ? mock(Node.Directory.class) : mock(Node.File.class)));
     when(mockBackup.delete(any())).thenReturn(false);
 
     // When

--- a/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -67,6 +69,23 @@ class BackupRunnerTest {
   }
 
   @Test
+  void whenDirectoryOnSourceAndNotDestination_skipsCreate() {
+    // Given
+    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
+    when(mockSourceFile.isDirectory()).thenReturn(true);
+    when(mockDestination.scan()).thenReturn(Map.of());
+
+    // When
+    OverallStatistics statistics = BackupRunner.run(mockBackup);
+
+    // Then
+    verify(mockBackup, never()).put("A");
+    assertThat(statistics)
+        .isEqualTo(
+            new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
+  }
+
+  @Test
   void whenFileOnSourceAndDestination_andNotSame_updatesFileOnDestination() {
     // Given
     when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
@@ -99,6 +118,24 @@ class BackupRunnerTest {
     assertThat(statistics)
         .isEqualTo(
             new OverallStatistics(new Statistics(0, 0, 0, 1, 0, 0), new ErrorStatistics(0, 0, 0)));
+  }
+
+  @Test
+  void whenDirectoryOnSourceAndDestination_skipsUpdate() {
+    // Given
+    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
+    when(mockSourceFile.isDirectory()).thenReturn(true);
+    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
+    when(mockDestinationFile.isDirectory()).thenReturn(true);
+
+    // When
+    OverallStatistics statistics = BackupRunner.run(mockBackup);
+
+    // Then
+    verify(mockBackup, never()).put("A");
+    assertThat(statistics)
+        .isEqualTo(
+            new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
   }
 
   @Test
@@ -136,58 +173,39 @@ class BackupRunnerTest {
   }
 
   @Test
-  void createsUpdatesAndDeletes() {
+  void whenDirectoryOnDestinationAndNotSource_deletesDirectoryFromDestination() {
     // Given
-    when(mockSource.scan())
-        .thenReturn(
-            Map.of(
-                "A",
-                mockSourceFile,
-                "B",
-                mockSourceFile,
-                "C",
-                mockSourceFile,
-                "D",
-                mockSourceFile,
-                "E",
-                mockSourceFile,
-                "F",
-                mockSourceFile));
-    when(mockDestination.scan())
-        .thenReturn(
-            Map.of(
-                "D",
-                mockDestinationFile,
-                "E",
-                mockDestinationFile,
-                "F",
-                mockDestinationFile,
-                "X",
-                mockDestinationFile,
-                "Y",
-                mockDestinationFile,
-                "Z",
-                mockDestinationFile));
-    when(mockBackup.put(any())).thenReturn(true);
+    when(mockSource.scan()).thenReturn(Map.of());
+    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
+    when(mockDestinationFile.isDirectory()).thenReturn(true);
     when(mockBackup.delete(any())).thenReturn(true);
-    when(mockSourceFile.same(mockDestinationFile)).thenReturn(false);
 
     // When
     OverallStatistics statistics = BackupRunner.run(mockBackup);
 
     // Then
-    verify(mockBackup).put("A");
-    verify(mockBackup).put("B");
-    verify(mockBackup).put("C");
-    verify(mockBackup).put("D");
-    verify(mockBackup).put("E");
-    verify(mockBackup).put("F");
-    verify(mockBackup).delete("X");
-    verify(mockBackup).delete("Y");
-    verify(mockBackup).delete("Z");
+    verify(mockBackup).delete("A");
     assertThat(statistics)
         .isEqualTo(
-            new OverallStatistics(new Statistics(3, 3, 3, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
+            new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
+  }
+
+  @Test
+  void whenDirectoryOnDestinationAndSource_skipsDelete() {
+    // Given
+    when(mockSource.scan()).thenReturn(Map.of("A", mockSourceFile));
+    when(mockSourceFile.isDirectory()).thenReturn(true);
+    when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
+    when(mockDestinationFile.isDirectory()).thenReturn(true);
+
+    // When
+    OverallStatistics statistics = BackupRunner.run(mockBackup);
+
+    // Then
+    verify(mockBackup, never()).delete("A");
+    assertThat(statistics)
+        .isEqualTo(
+            new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
   }
 
   @Test
@@ -224,11 +242,13 @@ class BackupRunnerTest {
             new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 1, 0)));
   }
 
-  @Test
-  void whenDeleteFails_countsFailedDelete() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void whenDeleteFails_countsFailedDelete(boolean isDirectory) {
     // Given
     when(mockSource.scan()).thenReturn(Map.of());
     when(mockDestination.scan()).thenReturn(Map.of("A", mockDestinationFile));
+    when(mockDestinationFile.isDirectory()).thenReturn(isDirectory);
     when(mockBackup.delete(any())).thenReturn(false);
 
     // When

--- a/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
@@ -3,7 +3,6 @@ package com.willmolloy.backup;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -77,7 +76,6 @@ class BackupRunnerTest {
     OverallStatistics statistics = BackupRunner.run(mockBackup);
 
     // Then
-    verify(mockBackup, never()).put("A");
     assertThat(statistics)
         .isEqualTo(
             new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
@@ -116,7 +114,6 @@ class BackupRunnerTest {
     OverallStatistics statistics = BackupRunner.run(mockBackup);
 
     // Then
-    verify(mockBackup, never()).put("A");
     assertThat(statistics)
         .isEqualTo(
             new OverallStatistics(new Statistics(0, 0, 0, 1, 0, 0), new ErrorStatistics(0, 0, 0)));
@@ -132,7 +129,38 @@ class BackupRunnerTest {
     OverallStatistics statistics = BackupRunner.run(mockBackup);
 
     // Then
-    verify(mockBackup, never()).put("A");
+    assertThat(statistics)
+        .isEqualTo(
+            new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
+  }
+
+  @Test
+  void whenFileOnSourceAndDirectoryOnDestination_overwritesDirectoryOnDestination() {
+    // Given
+    when(mockSource.scan()).thenReturn(Map.of("A", mock(Node.File.class)));
+    when(mockDestination.scan()).thenReturn(Map.of("A", mock(Node.Directory.class)));
+    when(mockBackup.put(any())).thenReturn(true);
+
+    // When
+    OverallStatistics statistics = BackupRunner.run(mockBackup);
+
+    // Then
+    verify(mockBackup).put("A");
+    assertThat(statistics)
+        .isEqualTo(
+            new OverallStatistics(new Statistics(1, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
+  }
+
+  @Test
+  void whenDirectoryOnSourceAndFileOnDestination_skipsUpdate() {
+    // Given
+    when(mockSource.scan()).thenReturn(Map.of("A", mock(Node.Directory.class)));
+    when(mockDestination.scan()).thenReturn(Map.of("A", mock(Node.File.class)));
+
+    // When
+    OverallStatistics statistics = BackupRunner.run(mockBackup);
+
+    // Then
     assertThat(statistics)
         .isEqualTo(
             new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));
@@ -168,7 +196,6 @@ class BackupRunnerTest {
     OverallStatistics statistics = BackupRunner.run(mockBackup);
 
     // Then
-    verify(mockBackup, never()).delete("A");
     assertThat(statistics)
         .isEqualTo(
             new OverallStatistics(new Statistics(0, 0, 0, 1, 0, 0), new ErrorStatistics(0, 0, 0)));
@@ -201,7 +228,6 @@ class BackupRunnerTest {
     OverallStatistics statistics = BackupRunner.run(mockBackup);
 
     // Then
-    verify(mockBackup, never()).delete("A");
     assertThat(statistics)
         .isEqualTo(
             new OverallStatistics(new Statistics(0, 0, 0, 0, 0, 0), new ErrorStatistics(0, 0, 0)));

--- a/file-backup-local/src/integrationTest/java/com/willmolloy/backup/local/LocalBackupIntegrationTest.java
+++ b/file-backup-local/src/integrationTest/java/com/willmolloy/backup/local/LocalBackupIntegrationTest.java
@@ -1,8 +1,207 @@
 package com.willmolloy.backup.local;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.willmolloy.backup.BackupRunner;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 /**
  * LocalBackupIntegrationTest.
  *
+ * <p>Quite simple as most logic is covered by unit tests.
+ *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-class LocalBackupIntegrationTest {}
+class LocalBackupIntegrationTest {
+
+  private FileSystem fs;
+  private Path sourceRoot;
+  private Path destRoot;
+  private LocalBackup sut;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    fs = Jimfs.newFileSystem(Configuration.forCurrentPlatform());
+    sourceRoot = Files.createDirectory(fs.getPath("Documents"));
+    destRoot = Files.createDirectory(fs.getPath("Backup"));
+    sut = new LocalBackup(new LocalStorage(sourceRoot), new LocalStorage(destRoot));
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    fs.close();
+  }
+
+  @Test
+  void createsFilesOnDestination() throws IOException {
+    // Given
+    // simple file
+    createFile(sourceRoot.resolve("A.txt"), "source text");
+    // empty directory
+    createDirectory(sourceRoot.resolve("B/C"));
+    // directory with multiple files
+    createFile(sourceRoot.resolve("D/E.mp4"), "source video");
+    createFile(sourceRoot.resolve("D/F.mp3"), "source audio");
+    // file nested deep
+    createFile(sourceRoot.resolve("X/Y/Z.pdf"), "source pdf");
+
+    // When
+    BackupRunner.OverallStatistics statistics = BackupRunner.run(sut);
+
+    // Then
+    assertThat(statistics)
+        .isEqualTo(
+            new BackupRunner.OverallStatistics(
+                new BackupRunner.Statistics(4, 0, 0, 0, 45, 0),
+                new BackupRunner.ErrorStatistics(0, 0, 0)));
+
+    assertThat(Files.walk(sourceRoot))
+        .containsExactly(
+            sourceRoot,
+            sourceRoot.resolve("A.txt"),
+            sourceRoot.resolve("B"),
+            sourceRoot.resolve("B/C"),
+            sourceRoot.resolve("D"),
+            sourceRoot.resolve("D/E.mp4"),
+            sourceRoot.resolve("D/F.mp3"),
+            sourceRoot.resolve("X"),
+            sourceRoot.resolve("X/Y"),
+            sourceRoot.resolve("X/Y/Z.pdf"));
+    assertThat(Files.walk(destRoot))
+        .containsExactly(
+            destRoot,
+            destRoot.resolve("A.txt"),
+            destRoot.resolve("D"),
+            destRoot.resolve("D/E.mp4"),
+            destRoot.resolve("D/F.mp3"),
+            destRoot.resolve("X"),
+            destRoot.resolve("X/Y"),
+            destRoot.resolve("X/Y/Z.pdf"));
+
+    assertThat(Files.readString(sourceRoot.resolve("A.txt"))).isEqualTo("source text");
+    assertThat(Files.readString(sourceRoot.resolve("D/E.mp4"))).isEqualTo("source video");
+    assertThat(Files.readString(sourceRoot.resolve("D/F.mp3"))).isEqualTo("source audio");
+    assertThat(Files.readString(sourceRoot.resolve("X/Y/Z.pdf"))).isEqualTo("source pdf");
+
+    assertThat(Files.readString(destRoot.resolve("A.txt"))).isEqualTo("source text");
+    assertThat(Files.readString(destRoot.resolve("D/E.mp4"))).isEqualTo("source video");
+    assertThat(Files.readString(destRoot.resolve("D/F.mp3"))).isEqualTo("source audio");
+    assertThat(Files.readString(destRoot.resolve("X/Y/Z.pdf"))).isEqualTo("source pdf");
+  }
+
+  @Test
+  void updatesFilesOnDestination() throws IOException {
+    // Given
+    // simple file
+    createFile(sourceRoot.resolve("A.txt"), "source text");
+    // empty directory
+    createDirectory(sourceRoot.resolve("B/C"));
+    // directory with multiple files
+    createFile(sourceRoot.resolve("D/E.mp4"), "source video");
+    createFile(sourceRoot.resolve("D/F.mp3"), "source audio");
+    // file nested deep
+    createFile(sourceRoot.resolve("X/Y/Z.pdf"), "source pdf");
+
+    // simple file
+    createFile(destRoot.resolve("A.txt"), "dest text");
+    // empty directory
+    createDirectory(destRoot.resolve("B/C"));
+    // directory with multiple files
+    createFile(destRoot.resolve("D/E.mp4"), "dest video");
+    createFile(destRoot.resolve("D/F.mp3"), "dest audio");
+    // file nested deep
+    createFile(destRoot.resolve("X/Y/Z.pdf"), "dest pdf");
+
+    // When
+    BackupRunner.OverallStatistics statistics = BackupRunner.run(sut);
+
+    // Then
+    assertThat(statistics)
+        .isEqualTo(
+            new BackupRunner.OverallStatistics(
+                new BackupRunner.Statistics(0, 4, 0, 0, 45, 37),
+                new BackupRunner.ErrorStatistics(0, 0, 0)));
+
+    assertThat(Files.walk(sourceRoot))
+        .containsExactly(
+            sourceRoot,
+            sourceRoot.resolve("A.txt"),
+            sourceRoot.resolve("B"),
+            sourceRoot.resolve("B/C"),
+            sourceRoot.resolve("D"),
+            sourceRoot.resolve("D/E.mp4"),
+            sourceRoot.resolve("D/F.mp3"),
+            sourceRoot.resolve("X"),
+            sourceRoot.resolve("X/Y"),
+            sourceRoot.resolve("X/Y/Z.pdf"));
+    assertThat(Files.walk(destRoot))
+        .containsExactly(
+            destRoot,
+            destRoot.resolve("A.txt"),
+            destRoot.resolve("D"),
+            destRoot.resolve("D/E.mp4"),
+            destRoot.resolve("D/F.mp3"),
+            destRoot.resolve("X"),
+            destRoot.resolve("X/Y"),
+            destRoot.resolve("X/Y/Z.pdf"));
+
+    assertThat(Files.readString(sourceRoot.resolve("A.txt"))).isEqualTo("source text");
+    assertThat(Files.readString(sourceRoot.resolve("D/E.mp4"))).isEqualTo("source video");
+    assertThat(Files.readString(sourceRoot.resolve("D/F.mp3"))).isEqualTo("source audio");
+    assertThat(Files.readString(sourceRoot.resolve("X/Y/Z.pdf"))).isEqualTo("source pdf");
+
+    assertThat(Files.readString(destRoot.resolve("A.txt"))).isEqualTo("source text");
+    assertThat(Files.readString(destRoot.resolve("D/E.mp4"))).isEqualTo("source video");
+    assertThat(Files.readString(destRoot.resolve("D/F.mp3"))).isEqualTo("source audio");
+    assertThat(Files.readString(destRoot.resolve("X/Y/Z.pdf"))).isEqualTo("source pdf");
+  }
+
+  @Test
+  void deletesFilesAndDirectoriesOnDestination() throws IOException {
+    // Given
+    // simple file
+    createFile(destRoot.resolve("A.txt"), "dest text");
+    // empty directory
+    createDirectory(destRoot.resolve("B/C"));
+    // directory with multiple files
+    createFile(destRoot.resolve("D/E.mp4"), "dest video");
+    createFile(destRoot.resolve("D/F.mp3"), "dest audio");
+    // file nested deep
+    createFile(destRoot.resolve("X/Y/Z.pdf"), "dest pdf");
+
+    // When
+    BackupRunner.OverallStatistics statistics = BackupRunner.run(sut);
+
+    // Then
+    assertThat(statistics)
+        .isEqualTo(
+            new BackupRunner.OverallStatistics(
+                new BackupRunner.Statistics(0, 0, 4, 0, 0, 37),
+                new BackupRunner.ErrorStatistics(0, 0, 0)));
+
+    assertThat(Files.walk(sourceRoot)).containsExactly(sourceRoot);
+    assertThat(Files.walk(destRoot)).containsExactly(destRoot);
+  }
+
+  private void createFile(Path path, String contents) throws IOException {
+    Path parent = path.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.createFile(path);
+    Files.writeString(path, contents);
+  }
+
+  private void createDirectory(Path path) throws IOException {
+    Files.createDirectories(path);
+  }
+}

--- a/file-backup-local/src/integrationTest/java/com/willmolloy/backup/local/LocalBackupIntegrationTest.java
+++ b/file-backup-local/src/integrationTest/java/com/willmolloy/backup/local/LocalBackupIntegrationTest.java
@@ -209,7 +209,7 @@ class LocalBackupIntegrationTest {
     assertThat(statistics)
         .isEqualTo(
             new BackupRunner.OverallStatistics(
-                new BackupRunner.Statistics(0, 1, 0, 0, 6, 0),
+                new BackupRunner.Statistics(1, 0, 0, 0, 6, 0),
                 new BackupRunner.ErrorStatistics(0, 0, 0)));
 
     assertThat(Files.walk(sourceRoot))

--- a/file-backup-local/src/integrationTest/java/com/willmolloy/backup/local/LocalBackupIntegrationTest.java
+++ b/file-backup-local/src/integrationTest/java/com/willmolloy/backup/local/LocalBackupIntegrationTest.java
@@ -1,0 +1,8 @@
+package com.willmolloy.backup.local;
+
+/**
+ * LocalBackupIntegrationTest.
+ *
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+class LocalBackupIntegrationTest {}

--- a/file-backup-local/src/integrationTest/java/com/willmolloy/backup/local/LocalBackupIntegrationTest.java
+++ b/file-backup-local/src/integrationTest/java/com/willmolloy/backup/local/LocalBackupIntegrationTest.java
@@ -147,6 +147,8 @@ class LocalBackupIntegrationTest {
         .containsExactly(
             destRoot,
             destRoot.resolve("A.txt"),
+            destRoot.resolve("B"),
+            destRoot.resolve("B/C"),
             destRoot.resolve("D"),
             destRoot.resolve("D/E.mp4"),
             destRoot.resolve("D/F.mp3"),
@@ -190,6 +192,38 @@ class LocalBackupIntegrationTest {
 
     assertThat(Files.walk(sourceRoot)).containsExactly(sourceRoot);
     assertThat(Files.walk(destRoot)).containsExactly(destRoot);
+  }
+
+  @Test
+  void overwritesDirectoryOnDestinationWithFileOnSource() throws IOException {
+    // Given
+    // bit of an edge case scenario... file matching dir name (i.e. no extension)
+    createFile(sourceRoot.resolve("A/B/C"), "hello!");
+    createDirectory(destRoot.resolve("A/B/C/D/E/F"));
+    createDirectory(destRoot.resolve("A/B/C/X/Y/Z"));
+
+    // When
+    BackupRunner.OverallStatistics statistics = BackupRunner.run(sut);
+
+    // Then
+    assertThat(statistics)
+        .isEqualTo(
+            new BackupRunner.OverallStatistics(
+                new BackupRunner.Statistics(0, 1, 0, 0, 6, 0),
+                new BackupRunner.ErrorStatistics(0, 0, 0)));
+
+    assertThat(Files.walk(sourceRoot))
+        .containsExactly(
+            sourceRoot,
+            sourceRoot.resolve("A"),
+            sourceRoot.resolve("A/B"),
+            sourceRoot.resolve("A/B/C"));
+    assertThat(Files.walk(destRoot))
+        .containsExactly(
+            destRoot, destRoot.resolve("A"), destRoot.resolve("A/B"), destRoot.resolve("A/B/C"));
+
+    assertThat(Files.readString(sourceRoot.resolve("A/B/C"))).isEqualTo("hello!");
+    assertThat(Files.readString(destRoot.resolve("A/B/C"))).isEqualTo("hello!");
   }
 
   private void createFile(Path path, String contents) throws IOException {

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -49,7 +49,7 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
       log.info("Copied: [{}] -> [{}]", sourcePath, destPath);
       return true;
     } catch (NoSuchFileException ignored) {
-      log.warn("Error copying: [{}] -> [{}]. Source file deleted since scan", sourcePath, destPath);
+      log.warn("Skipped copy: [{}] -> [{}]. Source file deleted since scan", sourcePath, destPath);
       return true;
     } catch (DirectoryNotEmptyException e) {
       log.warn(

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -66,7 +66,7 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
   public boolean delete(String key) {
     Path destPath = destination.root().resolve(key);
     try {
-      Files.walkFileTree(destPath, new DirectoryCleaner());
+      Files.walkFileTree(destPath, new RecursiveDelete());
       log.info("Deleted: [{}]", destPath);
       return true;
     } catch (NoSuchFileException ignored) {
@@ -77,10 +77,10 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
     }
   }
 
-  // multiple threads are running recursive delete (recursive is the only way to make this
-  // thread-safe - can't delete in order)
+  // multiple threads are running recursive delete
+  // (this is the only way to run in parallel - can't guarantee the order)
   // so ignore 'NoSuchFileException' as another thread may have got there first.
-  private static final class DirectoryCleaner implements FileVisitor<Path> {
+  private static final class RecursiveDelete implements FileVisitor<Path> {
     @Override
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attributes) {
       return FileVisitResult.CONTINUE;

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -49,6 +49,7 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
       log.info("Copied: [{}] -> [{}]", sourcePath, destPath);
       return true;
     } catch (NoSuchFileException ignored) {
+      log.warn("Error copying: [{}] -> [{}]. Source file deleted since scan", sourcePath, destPath);
       return true;
     } catch (DirectoryNotEmptyException e) {
       log.warn(

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -64,48 +64,7 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
   public boolean delete(String key) {
     Path destPath = destination.root().resolve(key);
     try {
-      Files.walkFileTree(
-          destPath,
-          // multiple threads are running recursive delete (recursive is the only way to make this
-          // thread-safe)
-          // so ignore 'NoSuchFileException' as another thread may have got there first.
-          new FileVisitor<>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-                throws IOException {
-              return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
-                throws IOException {
-              Files.deleteIfExists(file);
-              return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFileFailed(Path file, IOException e) throws IOException {
-              if (e instanceof NoSuchFileException) {
-                return FileVisitResult.CONTINUE;
-              } else {
-                log.error("Error visiting file: [%s]".formatted(file), e);
-                throw e;
-              }
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
-              if (e != null) {
-                if (e instanceof NoSuchFileException) {
-                  return FileVisitResult.CONTINUE;
-                }
-                log.error("Error visiting directory: [%s]".formatted(dir), e);
-                throw e;
-              }
-              Files.deleteIfExists(dir);
-              return FileVisitResult.CONTINUE;
-            }
-          });
+      Files.walkFileTree(destPath, new DirectoryCleaner());
       log.info("Deleted: [{}]", destPath);
       return true;
     } catch (NoSuchFileException ignored) {
@@ -113,6 +72,45 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
     } catch (IOException e) {
       log.error("Error deleting: [%s]".formatted(destPath), e);
       return false;
+    }
+  }
+
+  // multiple threads are running recursive delete (recursive is the only way to make this
+  // thread-safe - can't delete in order)
+  // so ignore 'NoSuchFileException' as another thread may have got there first.
+  private static final class DirectoryCleaner implements FileVisitor<Path> {
+    @Override
+    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attributes) {
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+      Files.deleteIfExists(file);
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException e) throws IOException {
+      if (e instanceof NoSuchFileException) {
+        return FileVisitResult.CONTINUE;
+      } else {
+        log.error("Error visiting file: [%s]".formatted(file), e);
+        throw e;
+      }
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
+      if (e != null) {
+        if (e instanceof NoSuchFileException) {
+          return FileVisitResult.CONTINUE;
+        }
+        log.error("Error visiting directory: [%s]".formatted(dir), e);
+        throw e;
+      }
+      Files.deleteIfExists(dir);
+      return FileVisitResult.CONTINUE;
     }
   }
 }

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -6,10 +6,10 @@ import com.willmolloy.backup.Backup;
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import org.apache.logging.log4j.LogManager;
@@ -66,7 +66,16 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
     try {
       Files.walkFileTree(
           destPath,
-          new SimpleFileVisitor<>() {
+          // multiple threads are running recursive delete (recursive is the only way to make this
+          // thread-safe)
+          // so ignore 'NoSuchFileException' as another thread may have got there first.
+          new FileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                throws IOException {
+              return FileVisitResult.CONTINUE;
+            }
+
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attributes)
                 throws IOException {
@@ -75,11 +84,22 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
             }
 
             @Override
+            public FileVisitResult visitFileFailed(Path file, IOException e) throws IOException {
+              if (e instanceof NoSuchFileException) {
+                return FileVisitResult.CONTINUE;
+              } else {
+                log.error("Error visiting file: [%s]".formatted(file), e);
+                throw e;
+              }
+            }
+
+            @Override
             public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
               if (e != null) {
                 if (e instanceof NoSuchFileException) {
                   return FileVisitResult.CONTINUE;
                 }
+                log.error("Error visiting directory: [%s]".formatted(dir), e);
                 throw e;
               }
               Files.deleteIfExists(dir);
@@ -88,7 +108,7 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
           });
       log.info("Deleted: [{}]", destPath);
       return true;
-    } catch (NoSuchFileException e) {
+    } catch (NoSuchFileException ignored) {
       return true;
     } catch (IOException e) {
       log.error("Error deleting: [%s]".formatted(destPath), e);

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -48,6 +48,8 @@ record LocalBackup(LocalStorage source, LocalStorage destination)
           StandardCopyOption.REPLACE_EXISTING);
       log.info("Copied: [{}] -> [{}]", sourcePath, destPath);
       return true;
+    } catch (NoSuchFileException ignored) {
+      return true;
     } catch (DirectoryNotEmptyException e) {
       log.warn(
           "Error copying: [{}] -> [{}]. Deleting non-empty directory on destination first",

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalDirectory.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalDirectory.java
@@ -1,0 +1,52 @@
+package com.willmolloy.backup.local;
+
+import static com.willmolloy.backup.util.Preconditions.require;
+import static java.util.Objects.requireNonNull;
+
+import com.willmolloy.backup.Backup;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
+
+/**
+ * Local directory on disk.
+ *
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+class LocalDirectory implements Backup.Node.Directory {
+
+  private final Path path;
+
+  LocalDirectory(Path path, BasicFileAttributes attributes) {
+    require(attributes.isDirectory(), "Requires a directory: [%s]".formatted(path));
+    this.path = requireNonNull(path);
+  }
+
+  LocalDirectory(Path path) throws IOException {
+    this(path, Files.readAttributes(path, BasicFileAttributes.class));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LocalDirectory localDirectory = (LocalDirectory) o;
+    return Objects.equals(path, localDirectory.path);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(path);
+  }
+
+  @Override
+  public String toString() {
+    return "%s[%s]".formatted(getClass().getSimpleName(), path);
+  }
+}

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
@@ -56,7 +56,7 @@ class LocalFile implements File {
   }
 
   Instant lastModified() {
-    return attributes.lastAccessTime().toInstant();
+    return attributes.lastModifiedTime().toInstant();
   }
 
   @Override

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
@@ -19,31 +19,28 @@ import java.util.Objects;
 class LocalFile implements File {
 
   private final Path path;
-  private final long size;
-  private final Instant lastModified;
+  private final BasicFileAttributes attributes;
 
   LocalFile(Path path, BasicFileAttributes attributes) {
     this.path = requireNonNull(path);
-    require(attributes.isRegularFile(), "Requires a file: [%s]".formatted(path));
-    this.size = attributes.size();
-    this.lastModified = attributes.lastModifiedTime().toInstant();
+    this.attributes = requireNonNull(attributes);
+    require(
+        attributes.isRegularFile() || attributes.isDirectory(),
+        "Requires a file or directory: [%s]".formatted(path));
   }
 
   LocalFile(Path path) throws IOException {
     this(path, Files.readAttributes(path, BasicFileAttributes.class));
   }
 
-  Path path() {
-    return path;
+  @Override
+  public long size() {
+    return attributes.size();
   }
 
   @Override
-  public long size() {
-    return size;
-  }
-
-  Instant lastModified() {
-    return lastModified;
+  public boolean isRegularFile() {
+    return attributes.isRegularFile();
   }
 
   @Override
@@ -52,6 +49,14 @@ class LocalFile implements File {
       return size() == other.size() && lastModified().equals(localFile.lastModified());
     }
     return File.super.same(other);
+  }
+
+  Path path() {
+    return path;
+  }
+
+  Instant lastModified() {
+    return attributes.lastAccessTime().toInstant();
   }
 
   @Override

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
@@ -39,8 +39,8 @@ class LocalFile implements File {
   }
 
   @Override
-  public boolean isRegularFile() {
-    return attributes.isRegularFile();
+  public boolean isDirectory() {
+    return attributes.isDirectory();
   }
 
   @Override

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
@@ -3,7 +3,7 @@ package com.willmolloy.backup.local;
 import static com.willmolloy.backup.util.Preconditions.require;
 import static java.util.Objects.requireNonNull;
 
-import com.willmolloy.backup.Backup.File;
+import com.willmolloy.backup.Backup.Node;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,17 +16,17 @@ import java.util.Objects;
  *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-class LocalFile implements File {
+class LocalFile implements Node.File {
 
   private final Path path;
-  private final BasicFileAttributes attributes;
+  private final long size;
+  private final Instant lastModified;
 
   LocalFile(Path path, BasicFileAttributes attributes) {
+    require(attributes.isRegularFile(), "Requires a file: [%s]".formatted(path));
     this.path = requireNonNull(path);
-    this.attributes = requireNonNull(attributes);
-    require(
-        attributes.isRegularFile() || attributes.isDirectory(),
-        "Requires a file or directory: [%s]".formatted(path));
+    this.size = attributes.size();
+    this.lastModified = attributes.lastModifiedTime().toInstant();
   }
 
   LocalFile(Path path) throws IOException {
@@ -35,12 +35,7 @@ class LocalFile implements File {
 
   @Override
   public long size() {
-    return attributes.size();
-  }
-
-  @Override
-  public boolean isDirectory() {
-    return attributes.isDirectory();
+    return size;
   }
 
   @Override
@@ -51,12 +46,8 @@ class LocalFile implements File {
     return File.super.same(other);
   }
 
-  Path path() {
-    return path;
-  }
-
   Instant lastModified() {
-    return attributes.lastModifiedTime().toInstant();
+    return lastModified;
   }
 
   @Override

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -4,6 +4,7 @@ import static com.willmolloy.backup.util.Preconditions.require;
 import static java.util.Objects.requireNonNull;
 
 import com.willmolloy.backup.Backup.Location;
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.AccessDeniedException;
@@ -14,6 +15,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -39,72 +41,27 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
   @Override
   public Map<String, LocalFile> scan() {
     log.info("Scanning directory: [{}]", root);
-
-    Map<String, LocalFile> map = new HashMap<>();
-
-    Function<Path, String> keyFunc =
-        ((Function<Path, Path>) root::relativize).andThen(LocalStorage::ensureUnixSeparator);
-
-    // not sure how duplicates occur?? But it does happen; take the most recently scanned file.
-    BiFunction<LocalFile, LocalFile, LocalFile> mergeFunc =
-        (first, second) -> {
-          log.warn("Scanned duplicate: [{}]", second.path());
-          return second;
-        };
-
     try {
-      Files.walkFileTree(
-          root,
-          new FileVisitor<>() {
-            @Override
-            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attributes) {
-              if (!attributes.isDirectory()) {
-                log.warn(
-                    "Skipped directory (not actually a directory): [{}]. Attributes: [{}]",
-                    dir,
-                    attributes);
-                return FileVisitResult.CONTINUE;
-              }
+      Map<String, LocalFile> map = new HashMap<>();
 
-              String key = keyFunc.apply(dir);
-              LocalFile localFile = new LocalFile(dir, attributes);
-              map.merge(key, localFile, mergeFunc);
-              return FileVisitResult.CONTINUE;
-            }
+      Function<Path, String> keyFunc =
+          ((Function<Path, Path>) root::relativize).andThen(LocalStorage::ensureUnixSeparator);
 
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
-              // TODO handle symlinks?
-              if (!attributes.isRegularFile()) {
-                log.warn(
-                    "Skipped file (not actually a file): [{}]. Attributes: [{}]", file, attributes);
-                return FileVisitResult.CONTINUE;
-              }
+      // not sure how duplicates occur?? But it does happen; take the most recently scanned file.
+      BiFunction<LocalFile, LocalFile, LocalFile> mergeFunc =
+          (first, second) -> {
+            log.warn("Scanned duplicate: [{}]", second.path());
+            return second;
+          };
 
-              String key = keyFunc.apply(file);
-              LocalFile localFile = new LocalFile(file, attributes);
-              map.merge(key, localFile, mergeFunc);
-              return FileVisitResult.CONTINUE;
-            }
+      BiConsumer<Path, BasicFileAttributes> consumer =
+          (path, attributes) -> {
+            String key = keyFunc.apply(path);
+            LocalFile localFile = new LocalFile(path, attributes);
+            map.merge(key, localFile, mergeFunc);
+          };
 
-            @Override
-            public FileVisitResult visitFileFailed(Path file, IOException e) {
-              if (e instanceof AccessDeniedException) {
-                log.warn("Skipped (access denied): [{}]", file);
-              } else {
-                log.error("Error visiting file: [%s]".formatted(file), e);
-              }
-              return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException e) {
-              if (e != null) {
-                log.error("Error visiting directory: [%s]".formatted(dir), e);
-              }
-              return FileVisitResult.CONTINUE;
-            }
-          });
+      Files.walkFileTree(root, new DirectoryScanner(consumer));
       return map;
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -112,7 +69,7 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
   }
 
   private static String ensureUnixSeparator(Path path) {
-    if (java.io.File.separatorChar == '/') {
+    if (File.separatorChar == '/') {
       return path.toString();
     } else {
       return StreamSupport.stream(path.spliterator(), false)
@@ -124,5 +81,55 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
   @Override
   public String toString() {
     return "%s[%s]".formatted(getClass().getSimpleName(), root);
+  }
+
+  private static final class DirectoryScanner implements FileVisitor<Path> {
+    private final BiConsumer<Path, BasicFileAttributes> consumer;
+
+    private DirectoryScanner(BiConsumer<Path, BasicFileAttributes> consumer) {
+      this.consumer = requireNonNull(consumer);
+    }
+
+    @Override
+    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attributes) {
+      if (!attributes.isDirectory()) {
+        log.warn(
+            "Skipped directory (not actually a directory): [{}]. Attributes: [{}]",
+            dir,
+            attributes);
+        return FileVisitResult.CONTINUE;
+      }
+      consumer.accept(dir, attributes);
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
+      // TODO handle symlinks?
+      if (!attributes.isRegularFile()) {
+        log.warn("Skipped file (not actually a file): [{}]. Attributes: [{}]", file, attributes);
+        return FileVisitResult.CONTINUE;
+      }
+      consumer.accept(file, attributes);
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult visitFileFailed(Path file, IOException e) {
+      if (e instanceof AccessDeniedException) {
+        log.warn("Skipped file (access denied): [{}]", file);
+      } else {
+        log.error("Error visiting file: [%s]".formatted(file), e);
+      }
+      return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException e) {
+      if (e != null) {
+        log.error("Error visiting directory: [%s]".formatted(dir), e);
+      }
+      return FileVisitResult.CONTINUE;
+    }
   }
 }

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -96,13 +96,6 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
 
     @Override
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attributes) {
-      if (!attributes.isDirectory()) {
-        log.warn(
-            "Skipped directory (not actually a directory): [{}]. Attributes: [{}]",
-            dir,
-            attributes);
-        return FileVisitResult.CONTINUE;
-      }
       consumer.accept(dir, attributes);
       return FileVisitResult.CONTINUE;
     }
@@ -110,8 +103,8 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
     @Override
     public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
       // TODO handle symlinks?
-      if (!attributes.isRegularFile()) {
-        log.warn("Skipped file (not actually a file): [{}]. Attributes: [{}]", file, attributes);
+      if (attributes.isSymbolicLink()) {
+        log.warn("Skipped file (symlink): [{}]", file);
         return FileVisitResult.CONTINUE;
       }
       consumer.accept(file, attributes);

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -58,17 +58,29 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
           new FileVisitor<>() {
             @Override
             public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attributes) {
+              if (!attributes.isDirectory()) {
+                log.warn(
+                    "Skipped directory (not actually a directory): [{}]. Attributes: [{}]",
+                    dir,
+                    attributes);
+                return FileVisitResult.CONTINUE;
+              }
+
+              String key = keyFunc.apply(dir);
+              LocalFile localFile = new LocalFile(dir, attributes);
+              map.merge(key, localFile, mergeFunc);
               return FileVisitResult.CONTINUE;
             }
 
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
-              if (attributes.isSymbolicLink()) {
-                log.warn("Skipped (symlink): [{}]", file);
+              // TODO handle symlinks?
+              if (!attributes.isRegularFile()) {
+                log.warn(
+                    "Skipped file (not actually a file): [{}]. Attributes: [{}]", file, attributes);
                 return FileVisitResult.CONTINUE;
               }
 
-              // limit to files only for now TODO what about backing up empty dirs?
               String key = keyFunc.apply(file);
               LocalFile localFile = new LocalFile(file, attributes);
               map.merge(key, localFile, mergeFunc);

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -56,6 +56,10 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
 
       BiConsumer<Path, BasicFileAttributes> consumer =
           (path, attributes) -> {
+            if (path == root) {
+              return;
+            }
+
             String key = keyFunc.apply(path);
             LocalFile localFile = new LocalFile(path, attributes);
             map.merge(key, localFile, mergeFunc);

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -3,6 +3,7 @@ package com.willmolloy.backup.local;
 import static com.willmolloy.backup.util.Preconditions.require;
 import static java.util.Objects.requireNonNull;
 
+import com.willmolloy.backup.Backup;
 import com.willmolloy.backup.Backup.Location;
 import java.io.File;
 import java.io.IOException;
@@ -29,7 +30,7 @@ import org.apache.logging.log4j.Logger;
  * @param root root directory
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public record LocalStorage(Path root) implements Location<LocalFile> {
+public record LocalStorage(Path root) implements Location {
 
   private static final Logger log = LogManager.getLogger();
 
@@ -39,33 +40,39 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
   }
 
   @Override
-  public Map<String, LocalFile> scan() {
+  public Map<String, Backup.Node> scan() {
     log.info("Scanning directory: [{}]", root);
     try {
-      Map<String, LocalFile> map = new HashMap<>();
+      Map<String, Backup.Node> map = new HashMap<>();
 
       Function<Path, String> keyFunc =
           ((Function<Path, Path>) root::relativize).andThen(LocalStorage::ensureUnixSeparator);
 
       // not sure how duplicates occur?? But it does happen; take the most recently scanned file.
-      BiFunction<LocalFile, LocalFile, LocalFile> mergeFunc =
+      BiFunction<Backup.Node, Backup.Node, Backup.Node> mergeFunc =
           (first, second) -> {
-            log.warn("Scanned duplicate: [{}]", second.path());
+            log.warn("Scanned duplicate: [{}]", second);
             return second;
           };
 
-      BiConsumer<Path, BasicFileAttributes> consumer =
+      BiConsumer<Path, BasicFileAttributes> fileConsumer =
           (path, attributes) -> {
-            if (path == root) {
-              return;
-            }
-
             String key = keyFunc.apply(path);
             LocalFile localFile = new LocalFile(path, attributes);
             map.merge(key, localFile, mergeFunc);
           };
 
-      Files.walkFileTree(root, new DirectoryScanner(consumer));
+      BiConsumer<Path, BasicFileAttributes> directoryConsumer =
+          (path, attributes) -> {
+            if (path == root) {
+              return;
+            }
+            String key = keyFunc.apply(path);
+            LocalDirectory localFile = new LocalDirectory(path, attributes);
+            map.merge(key, localFile, mergeFunc);
+          };
+
+      Files.walkFileTree(root, new DirectoryScanner(fileConsumer, directoryConsumer));
       return map;
     } catch (IOException e) {
       throw new UncheckedIOException(e);
@@ -88,15 +95,19 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
   }
 
   private static final class DirectoryScanner implements FileVisitor<Path> {
-    private final BiConsumer<Path, BasicFileAttributes> consumer;
+    private final BiConsumer<Path, BasicFileAttributes> fileConsumer;
+    private final BiConsumer<Path, BasicFileAttributes> directoryConsumer;
 
-    private DirectoryScanner(BiConsumer<Path, BasicFileAttributes> consumer) {
-      this.consumer = requireNonNull(consumer);
+    private DirectoryScanner(
+        BiConsumer<Path, BasicFileAttributes> fileConsumer,
+        BiConsumer<Path, BasicFileAttributes> directoryConsumer) {
+      this.fileConsumer = requireNonNull(fileConsumer);
+      this.directoryConsumer = requireNonNull(directoryConsumer);
     }
 
     @Override
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attributes) {
-      consumer.accept(dir, attributes);
+      directoryConsumer.accept(dir, attributes);
       return FileVisitResult.CONTINUE;
     }
 
@@ -107,7 +118,7 @@ public record LocalStorage(Path root) implements Location<LocalFile> {
         log.warn("Skipped file (symlink): [{}]", file);
         return FileVisitResult.CONTINUE;
       }
-      consumer.accept(file, attributes);
+      fileConsumer.accept(file, attributes);
       return FileVisitResult.CONTINUE;
     }
 

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalBackupTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalBackupTest.java
@@ -164,7 +164,7 @@ class LocalBackupTest {
     boolean result = assertDoesNotThrow(() -> sut.put("A"));
 
     // Then
-    assertThat(result).isFalse();
+    assertThat(result).isTrue();
     assertThatFileSystem().isEmpty();
   }
 

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalDirectoryTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalDirectoryTest.java
@@ -46,7 +46,7 @@ class LocalDirectoryTest {
   }
 
   @Test
-  void constructor_requiresValidFile() {
+  void constructor_requiresValidDirectory() {
     IllegalArgumentException thrown =
         assertThrows(
             IllegalArgumentException.class,

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalDirectoryTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalDirectoryTest.java
@@ -5,12 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalDirectoryTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalDirectoryTest.java
@@ -1,0 +1,59 @@
+package com.willmolloy.backup.local;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * LocalDirectoryTest.
+ *
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+@SuppressFBWarnings("UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR")
+class LocalDirectoryTest {
+
+  private FileSystem fs;
+  private Path root;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    fs = Jimfs.newFileSystem(Configuration.forCurrentPlatform());
+
+    root = fs.getPath("root");
+    Files.createDirectory(root);
+  }
+
+  @AfterEach
+  void tearDown() throws IOException {
+    fs.close();
+  }
+
+  @Test
+  void toString_includesPath() throws IOException {
+    Path path = Files.createDirectory(root.resolve("ABCD"));
+    LocalDirectory file = new LocalDirectory(path);
+    assertThat(file.toString()).isEqualTo("LocalDirectory[%s]".formatted(path));
+  }
+
+  @Test
+  void constructor_requiresValidFile() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new LocalDirectory(Files.createFile(root.resolve("A"))));
+    assertThat(thrown)
+        .hasMessageThat()
+        .isEqualTo("Requires a directory: [%s]".formatted(root.resolve("A")));
+  }
+}

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalFileTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalFileTest.java
@@ -1,7 +1,6 @@
 package com.willmolloy.backup.local;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -81,17 +80,6 @@ class LocalFileTest {
     long currentMillis = System.currentTimeMillis();
     assertThat(result.toEpochMilli())
         .isIn(Range.closed(currentMillis - tolerance, currentMillis + tolerance));
-  }
-
-  @Test
-  void constructor_requiresValidFile() {
-    IllegalArgumentException thrown =
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new LocalFile(Files.createDirectory(root.resolve("A"))));
-    assertThat(thrown)
-        .hasMessageThat()
-        .isEqualTo("Requires a file: [%s]".formatted(root.resolve("A")));
   }
 
   @ParameterizedTest

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalFileTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalFileTest.java
@@ -126,7 +126,7 @@ class LocalFileTest {
     Files.writeString(thisFilePath, thisContents);
     LocalFile thisFile = spy(new LocalFile(thisFilePath));
 
-    Backup.File otherFile = mock(Backup.File.class);
+    Backup.Node.File otherFile = mock(Backup.Node.File.class);
     when(otherFile.size()).thenReturn((long) otherContents.length());
 
     // Then

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalFileTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalFileTest.java
@@ -1,6 +1,7 @@
 package com.willmolloy.backup.local;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -146,5 +147,16 @@ class LocalFileTest {
     Path path = Files.createFile(root.resolve("ABCD"));
     LocalFile file = new LocalFile(path);
     assertThat(file.toString()).isEqualTo("LocalFile[%s]".formatted(path));
+  }
+
+  @Test
+  void constructor_requiresValidFile() {
+    IllegalArgumentException thrown =
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new LocalFile(Files.createDirectory(root.resolve("A"))));
+    assertThat(thrown)
+        .hasMessageThat()
+        .isEqualTo("Requires a file: [%s]".formatted(root.resolve("A")));
   }
 }

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import com.willmolloy.backup.Backup;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -61,22 +62,22 @@ class LocalStorageTest {
     Files.createFile(root.resolve("X/Y/Z"));
 
     // When
-    Map<String, LocalFile> scan = sut.scan();
+    Map<String, Backup.Node> scan = sut.scan();
 
     // Then
     assertThat(scan)
         .containsExactly(
             "A", new LocalFile(root.resolve("A")),
             "B", new LocalFile(root.resolve("B")),
-            "C", new LocalFile(root.resolve("C")),
-            "C/D", new LocalFile(root.resolve("C/D")),
+            "C", new LocalDirectory(root.resolve("C")),
+            "C/D", new LocalDirectory(root.resolve("C/D")),
             "C/D/E", new LocalFile(root.resolve("C/D/E")),
-            "F", new LocalFile(root.resolve("F")),
-            "F/G", new LocalFile(root.resolve("F/G")),
-            "F/G/H", new LocalFile(root.resolve("F/G/H")),
+            "F", new LocalDirectory(root.resolve("F")),
+            "F/G", new LocalDirectory(root.resolve("F/G")),
+            "F/G/H", new LocalDirectory(root.resolve("F/G/H")),
             "F/G/H/I", new LocalFile(root.resolve("F/G/H/I")),
-            "X", new LocalFile(root.resolve("X")),
-            "X/Y", new LocalFile(root.resolve("X/Y")),
+            "X", new LocalDirectory(root.resolve("X")),
+            "X/Y", new LocalDirectory(root.resolve("X/Y")),
             "X/Y/Z", new LocalFile(root.resolve("X/Y/Z")));
   }
 

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
@@ -49,16 +49,16 @@ class LocalStorageTest {
   }
 
   @Test
-  void scan_returnsMapOfRelativizedFileNamesToFiles() throws IOException {
+  void scan_returnsMapOfRelativizedFileNamesToFilesAndDirectories() throws IOException {
     // Given
-    Path a = Files.createFile(root.resolve("A"));
-    Path b = Files.createFile(root.resolve("B"));
+    Files.createFile(root.resolve("A"));
+    Files.createFile(root.resolve("B"));
     Files.createDirectories(root.resolve("C/D"));
-    Path e = Files.createFile(root.resolve("C/D/E"));
+    Files.createFile(root.resolve("C/D/E"));
     Files.createDirectories(root.resolve("F/G/H"));
-    Path i = Files.createFile(root.resolve("F/G/H/I"));
+    Files.createFile(root.resolve("F/G/H/I"));
     Files.createDirectories(root.resolve("X/Y"));
-    Path z = Files.createFile(root.resolve("X/Y/Z"));
+    Files.createFile(root.resolve("X/Y/Z"));
 
     // When
     Map<String, LocalFile> scan = sut.scan();
@@ -66,11 +66,18 @@ class LocalStorageTest {
     // Then
     assertThat(scan)
         .containsExactly(
-            "A", new LocalFile(a),
-            "B", new LocalFile(b),
-            "C/D/E", new LocalFile(e),
-            "F/G/H/I", new LocalFile(i),
-            "X/Y/Z", new LocalFile(z));
+            "A", new LocalFile(root.resolve("A")),
+            "B", new LocalFile(root.resolve("B")),
+            "C", new LocalFile(root.resolve("C")),
+            "C/D", new LocalFile(root.resolve("C/D")),
+            "C/D/E", new LocalFile(root.resolve("C/D/E")),
+            "F", new LocalFile(root.resolve("F")),
+            "F/G", new LocalFile(root.resolve("F/G")),
+            "F/G/H", new LocalFile(root.resolve("F/G/H")),
+            "F/G/H/I", new LocalFile(root.resolve("F/G/H/I")),
+            "X", new LocalFile(root.resolve("X")),
+            "X/Y", new LocalFile(root.resolve("X/Y")),
+            "X/Y/Z", new LocalFile(root.resolve("X/Y/Z")));
   }
 
   @Test

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -63,7 +63,7 @@ class S3Backup implements Backup<LocalStorage, S3Bucket> {
       return true;
     } catch (NoSuchFileException ignored) {
       log.warn(
-          "Error putting: [{}] -> [{}]. Source file deleted since scan",
+          "Skipped put: [{}] -> [{}]. Source file deleted since scan",
           sourcePath,
           destinationUri);
       return true;

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import com.willmolloy.backup.Backup;
 import com.willmolloy.backup.local.LocalStorage;
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -59,6 +60,12 @@ class S3Backup implements Backup<LocalStorage, S3Bucket> {
               .build();
       s3Client.putObject(request, sourcePath);
       log.info("Put: [{}] -> [{}]", sourcePath, destinationUri);
+      return true;
+    } catch (NoSuchFileException ignored) {
+      log.warn(
+          "Error putting: [{}] -> [{}]. Source file deleted since scan",
+          sourcePath,
+          destinationUri);
       return true;
     } catch (RuntimeException | IOException e) {
       log.error("Error putting: [%s] -> [%s]".formatted(sourcePath, destinationUri), e);

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -63,9 +63,7 @@ class S3Backup implements Backup<LocalStorage, S3Bucket> {
       return true;
     } catch (NoSuchFileException ignored) {
       log.warn(
-          "Skipped put: [{}] -> [{}]. Source file deleted since scan",
-          sourcePath,
-          destinationUri);
+          "Skipped put: [{}] -> [{}]. Source file deleted since scan", sourcePath, destinationUri);
       return true;
     } catch (RuntimeException | IOException e) {
       log.error("Error putting: [%s] -> [%s]".formatted(sourcePath, destinationUri), e);

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Bucket.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Bucket.java
@@ -4,6 +4,7 @@ import static com.willmolloy.backup.util.Preconditions.require;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 
+import com.willmolloy.backup.Backup;
 import com.willmolloy.backup.Backup.Location;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
@@ -17,7 +18,7 @@ import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
  *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-class S3Bucket implements Location<S3File> {
+class S3Bucket implements Location {
 
   private static final Logger log = LogManager.getLogger();
 
@@ -36,7 +37,7 @@ class S3Bucket implements Location<S3File> {
   }
 
   @Override
-  public Map<String, S3File> scan() {
+  public Map<String, Backup.Node> scan() {
     log.info("Scanning bucket: [{}]", bucketUri());
     ListObjectsV2Request request =
         ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build();

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3File.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3File.java
@@ -30,4 +30,10 @@ record S3File(S3Object s3Object) implements File {
       return 0;
     }
   }
+
+  @Override
+  public boolean isRegularFile() {
+    // 's3 list' only returns files (i.e. objects), no folders
+    return true;
+  }
 }

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3File.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3File.java
@@ -2,7 +2,7 @@ package com.willmolloy.backup.s3;
 
 import static java.util.Objects.requireNonNull;
 
-import com.willmolloy.backup.Backup.File;
+import com.willmolloy.backup.Backup.Node;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.s3.model.S3Object;
@@ -13,7 +13,7 @@ import software.amazon.awssdk.services.s3.model.S3Object;
  * @param s3Object the underlying S3 object
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-record S3File(S3Object s3Object) implements File {
+record S3File(S3Object s3Object) implements Node.File {
 
   private static final Logger log = LogManager.getLogger();
 
@@ -29,11 +29,5 @@ record S3File(S3Object s3Object) implements File {
       log.error("Error getting size of object: [%s]".formatted(s3Object), e);
       return 0;
     }
-  }
-
-  @Override
-  public boolean isDirectory() {
-    // 's3 list' only returns files (i.e. objects), no folders
-    return true;
   }
 }

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3File.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3File.java
@@ -32,7 +32,7 @@ record S3File(S3Object s3Object) implements File {
   }
 
   @Override
-  public boolean isRegularFile() {
+  public boolean isDirectory() {
     // 's3 list' only returns files (i.e. objects), no folders
     return true;
   }

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
@@ -98,9 +98,24 @@ class S3BackupTest {
   }
 
   @Test
-  void put_failsGracefully() {
+  void put_whenFileNotOnSource_failsGracefully() {
     // When
     boolean result = assertDoesNotThrow(() -> sut.put(fakeFileName()));
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void put_whenS3Error_failsGracefully() throws IOException {
+    // Given
+    String key = fakeFileName();
+    createSourcePath(key);
+    when(mockS3Client.putObject(any(PutObjectRequest.class), any(Path.class)))
+        .thenThrow(new RuntimeException());
+
+    // When
+    boolean result = assertDoesNotThrow(() -> sut.put(key));
 
     // Then
     assertThat(result).isFalse();
@@ -125,7 +140,7 @@ class S3BackupTest {
   }
 
   @Test
-  void delete_failsGracefully() {
+  void delete_whenS3Error_failsGracefully() {
     // Given
     when(mockS3Client.deleteObject(any(DeleteObjectRequest.class)))
         .thenThrow(new RuntimeException());

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BucketTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BucketTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.willmolloy.backup.Backup;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -66,7 +67,7 @@ class S3BucketTest {
     when(mockS3Client.listObjectsV2Paginator(request)).thenReturn(response);
 
     // When
-    Map<String, S3File> scan = sut.scan();
+    Map<String, Backup.Node> scan = sut.scan();
 
     // Then
     assertThat(scan)

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3FileTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3FileTest.java
@@ -57,7 +57,7 @@ class S3FileTest {
     // Given
     S3File thisFile = spy(new S3File(S3Object.builder().size(thisSize).build()));
 
-    Backup.File otherFile = mock(Backup.File.class);
+    Backup.Node.File otherFile = mock(Backup.Node.File.class);
     when(otherFile.size()).thenReturn(otherSize);
 
     // Then


### PR DESCRIPTION
- Now deletes directories on destination that aren't on source
- Partially solves #4 
- Attempted to handle copying empty dirs... but it gets messy and impacts performance as an IO call is required to test 'is empty dir' (see comments)
