### PR TITLE
Avoid redundant `scan` when deleting and other optimisations

### DIFF
--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -1,9 +1,6 @@
 package com.willmolloy.backup;
 
-import static java.util.function.Predicate.not;
-
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.nio.file.Path;
 import java.text.NumberFormat;
 import java.time.Duration;
 import java.util.Locale;
@@ -11,6 +8,7 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -42,56 +40,54 @@ public final class BackupRunner {
     try (ExecutorService threadPool =
         Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("worker-", 1).factory())) {
 
-      FileTree<SourceFileT> sourceFiles = scanWithLog(backup.source()::scan, "source");
-      FileTree<DestFileT> destFiles = scanWithLog(backup.destination()::scan, "destination");
+      FileTree<SourceFileT> sourceFileTree = scanWithLog(backup.source()::scan, "source");
+      FileTree<DestFileT> destFileTree = scanWithLog(backup.destination()::scan, "destination");
 
-      sourceFiles.forEach(
-          (sourceFile) -> {
-            Path key = sourceFile.relativePath();
+      sourceFileTree
+          .preorder()
+          // only need to put leaves
+          // TODO postorder and stop at first non-leaf?
+          .filter(
+              sourceFile ->
+                  sourceFileTree
+                      .descendants(sourceFile.relativePath())
+                      .noneMatch(descendant -> true))
+          .filter(
+              sourceFile -> {
+                Optional<DestFileT> maybeDestFile = destFileTree.get(sourceFile.relativePath());
+                if (maybeDestFile.isEmpty() || !sourceFile.same(maybeDestFile.get())) {
+                  return true;
+                }
+                log.debug("Skipping put. Files same({}, {})", sourceFile, maybeDestFile.get());
+                return false;
+              })
+          .forEach(
+              sourceFile ->
+                  threadPool.submit(
+                      () -> {
+                        EntryMessage m = log.traceEntry("put({})", sourceFile);
+                        if (!log.traceExit(m, backup.put(sourceFile))) {
+                          allSuccess.set(false);
+                        }
+                      }));
 
-            if (sourceFiles.descendants(key).anyMatch(descendant -> true)) {
-              log.debug("Skipping put({}). Covered by descendant", key);
-              return;
-            }
-
-            Optional<DestFileT> maybeDestFile = destFiles.get(key);
-            if (maybeDestFile.isEmpty() || !sourceFile.same(maybeDestFile.get())) {
-              threadPool.submit(
-                  () -> {
-                    EntryMessage m = log.traceEntry("put({})", sourceFile);
-                    if (!log.traceExit(m, backup.put(sourceFile))) {
-                      allSuccess.set(false);
-                    }
-                  });
-            } else {
-              log.trace("same({})", key);
-            }
-          });
-
-      destFiles.forEach(
-          (destFile) -> {
-            Path key = destFile.relativePath();
-
-            if (sourceFiles.contains(key)) {
-              return;
-            }
-
-            if (destFiles
-                .ancestors(key)
-                .map(File::relativePath)
-                .anyMatch(not(sourceFiles::contains))) {
-              log.debug("Skipping delete({}). Covered by ancestor", key);
-              return;
-            }
-
-            threadPool.submit(
-                () -> {
-                  EntryMessage m = log.traceEntry("delete({})", destFile);
-                  if (!log.traceExit(m, backup.delete(destFile))) {
-                    allSuccess.set(false);
-                  }
-                });
-          });
+      Predicate<DestFileT> shouldDelete =
+          destFile -> !sourceFileTree.contains(destFile.relativePath());
+      destFileTree
+          .preorder()
+          .filter(shouldDelete)
+          // skip delete if covered by ancestor
+          .filter(
+              destFile -> destFileTree.ancestors(destFile.relativePath()).noneMatch(shouldDelete))
+          .forEach(
+              destFile ->
+                  threadPool.submit(
+                      () -> {
+                        EntryMessage m = log.traceEntry("delete({})", destFile);
+                        if (!log.traceExit(m, backup.delete(destFile))) {
+                          allSuccess.set(false);
+                        }
+                      }));
     }
 
     log.info("Finished: {} in: {}", backup, elapsed(runStartNanos));

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -62,7 +62,7 @@ public final class BackupRunner {
               });
 
       Predicate<DestFileT> canDelete =
-          destFile -> sourceFileTree.get(destFile.relativePath()).isEmpty();
+          destFile -> !sourceFileTree.contains(destFile.relativePath());
       destFileTree
           .postorder()
           .filter(canDelete)

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -46,12 +46,8 @@ public final class BackupRunner {
       sourceFileTree
           .preorder()
           // only need to put leaves
-          // TODO postorder and stop at first non-leaf?
           .filter(
-              sourceFile ->
-                  sourceFileTree
-                      .descendants(sourceFile.relativePath())
-                      .noneMatch(descendant -> true))
+              sourceFile -> sourceFileTree.descendants(sourceFile).noneMatch(descendant -> true))
           .filter(
               sourceFile -> {
                 Optional<DestFileT> maybeDestFile = destFileTree.get(sourceFile.relativePath());
@@ -71,14 +67,13 @@ public final class BackupRunner {
                         }
                       }));
 
-      Predicate<DestFileT> shouldDelete =
-          destFile -> !sourceFileTree.contains(destFile.relativePath());
+      Predicate<DestFileT> canDelete =
+          destFile -> sourceFileTree.get(destFile.relativePath()).isEmpty();
       destFileTree
           .preorder()
-          .filter(shouldDelete)
+          .filter(canDelete)
           // skip delete if covered by ancestor
-          .filter(
-              destFile -> destFileTree.ancestors(destFile.relativePath()).noneMatch(shouldDelete))
+          .filter(destFile -> destFileTree.ancestors(destFile).noneMatch(canDelete))
           .forEach(
               destFile ->
                   threadPool.submit(

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -1,15 +1,13 @@
 package com.willmolloy.backup;
 
+import static com.willmolloy.backup.util.TimeHelper.elapsed;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.text.NumberFormat;
-import java.time.Duration;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -25,8 +23,6 @@ import org.apache.logging.log4j.Logger;
 public final class BackupRunner {
 
   private static final Logger log = LogManager.getLogger();
-  private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance(Locale.ENGLISH);
-  private static final int MEGA = 1_000_000;
 
   /** Runs the backup. */
   public static <SourceFileT extends File, DestFileT extends File> boolean run(
@@ -39,8 +35,8 @@ public final class BackupRunner {
     try (ExecutorService threadPool =
         Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("worker-", 1).factory())) {
 
-      FileTree<SourceFileT> sourceFileTree = scanWithLog(backup.source()::scan, "source");
-      FileTree<DestFileT> destFileTree = scanWithLog(backup.destination()::scan, "destination");
+      FileTree<SourceFileT> sourceFileTree = backup.source().fileTree();
+      FileTree<DestFileT> destFileTree = backup.destination().fileTree();
 
       sourceFileTree
           // only need to put leaves
@@ -81,23 +77,6 @@ public final class BackupRunner {
 
     log.info("Finished: {} in: {}", backup, elapsed(runStartNanos));
     return allSuccess.get();
-  }
-
-  private static <FileT extends File> FileTree<FileT> scanWithLog(
-      Supplier<FileTree<FileT>> scan, String locationForLog) {
-    long scanStartNanos = System.nanoTime();
-    FileTree<FileT> fileTree = scan.get();
-    log.info(
-        "Scanned {} in: {}. {} files. {}MB",
-        locationForLog,
-        elapsed(scanStartNanos),
-        NUMBER_FORMAT.format(fileTree.fileCount()),
-        NUMBER_FORMAT.format(fileTree.totalSize() / MEGA));
-    return fileTree;
-  }
-
-  private static Duration elapsed(long startNanos) {
-    return Duration.ofNanos(System.nanoTime() - startNanos);
   }
 
   private BackupRunner() {}

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -12,7 +12,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.EntryMessage;
 
 /**
  * Runs a {@link Backup}.
@@ -46,24 +45,21 @@ public final class BackupRunner {
       sourceFileTree
           // only need to put leaves
           .leaves()
-          .filter(
+          .forEach(
               sourceFile -> {
                 Optional<DestFileT> maybeDestFile = destFileTree.get(sourceFile.relativePath());
                 if (maybeDestFile.isEmpty() || !sourceFile.same(maybeDestFile.get())) {
-                  return true;
-                }
-                log.debug("Skipping put. Files same({}, {})", sourceFile, maybeDestFile.get());
-                return false;
-              })
-          .forEach(
-              sourceFile ->
                   threadPool.submit(
                       () -> {
-                        EntryMessage m = log.traceEntry("put({})", sourceFile);
-                        if (!log.traceExit(m, backup.put(sourceFile))) {
+                        log.debug("put({}, {})", sourceFile, maybeDestFile);
+                        if (!backup.put(sourceFile)) {
                           allSuccess.set(false);
                         }
-                      }));
+                      });
+                } else {
+                  log.debug("same({}, {})", sourceFile, maybeDestFile.get());
+                }
+              });
 
       Predicate<DestFileT> canDelete =
           destFile -> sourceFileTree.get(destFile.relativePath()).isEmpty();
@@ -76,13 +72,14 @@ public final class BackupRunner {
               destFile ->
                   threadPool.submit(
                       () -> {
-                        EntryMessage m = log.traceEntry("delete({})", destFile);
-                        if (!log.traceExit(m, backup.delete(destFile))) {
+                        log.debug("delete({})", destFile);
+                        if (!backup.delete(destFile)) {
                           allSuccess.set(false);
                         }
                       }));
     }
 
+    // TODO post condition? i.e. scan and ensure sync?
     log.info("Finished: {} in: {}", backup, elapsed(runStartNanos));
     return allSuccess.get();
   }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -44,10 +44,8 @@ public final class BackupRunner {
       FileTree<DestFileT> destFileTree = scanWithLog(backup.destination()::scan, "destination");
 
       sourceFileTree
-          .preorder()
           // only need to put leaves
-          .filter(
-              sourceFile -> sourceFileTree.descendants(sourceFile).noneMatch(descendant -> true))
+          .leaves()
           .filter(
               sourceFile -> {
                 Optional<DestFileT> maybeDestFile = destFileTree.get(sourceFile.relativePath());

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -79,7 +79,6 @@ public final class BackupRunner {
                       }));
     }
 
-    // TODO post condition? i.e. scan and ensure sync?
     log.info("Finished: {} in: {}", backup, elapsed(runStartNanos));
     return allSuccess.get();
   }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -68,7 +68,7 @@ public final class BackupRunner {
       Predicate<DestFileT> canDelete =
           destFile -> sourceFileTree.get(destFile.relativePath()).isEmpty();
       destFileTree
-          .preorder()
+          .postorder()
           .filter(canDelete)
           // skip delete if covered by ancestor
           .filter(destFile -> destFileTree.ancestors(destFile).noneMatch(canDelete))

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BackupRunner.java
@@ -33,7 +33,7 @@ public final class BackupRunner {
     AtomicBoolean allSuccess = new AtomicBoolean(true);
 
     try (ExecutorService threadPool =
-        Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("worker-", 1).factory())) {
+        Executors.newFixedThreadPool(10, Thread.ofVirtual().name("worker-", 1).factory())) {
 
       FileTree<SourceFileT> sourceFileTree = backup.source().fileTree();
       FileTree<DestFileT> destFileTree = backup.destination().fileTree();

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BaseLocation.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BaseLocation.java
@@ -8,7 +8,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Base {@link Location} class. Caches the {@link FileTree} after scan.
+ * Base {@link Location} class. Caches the scanned {@link FileTree}.
  *
  * @param <FileT> type of file stored in this location
  * @author <a href=https://willmolloy.com>Will Molloy</a>
@@ -28,9 +28,10 @@ public abstract class BaseLocation<FileT extends File> implements Location<FileT
       synchronized (this) {
         if (fileTree == null) {
           long scanStartNanos = System.nanoTime();
+          log.info("Scanning: {}", this);
           FileTree<FileT> fileTree = scan();
           log.info(
-              "Scanned {} in: {}. {} files. {}MB",
+              "Scanned: {} in: {}. {} files. {}MB",
               this,
               elapsed(scanStartNanos),
               NUMBER_FORMAT.format(fileTree.fileCount()),

--- a/file-backup-core/src/main/java/com/willmolloy/backup/BaseLocation.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/BaseLocation.java
@@ -1,0 +1,46 @@
+package com.willmolloy.backup;
+
+import static com.willmolloy.backup.util.TimeHelper.elapsed;
+
+import java.text.NumberFormat;
+import java.util.Locale;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Base {@link Location} class. Caches the {@link FileTree} after scan.
+ *
+ * @param <FileT> type of file stored in this location
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+public abstract class BaseLocation<FileT extends File> implements Location<FileT> {
+
+  private static final Logger log = LogManager.getLogger();
+  private static final NumberFormat NUMBER_FORMAT = NumberFormat.getInstance(Locale.ENGLISH);
+  private static final int MEGA = 1_000_000;
+
+  private volatile FileTree<FileT> fileTree;
+
+  @Override
+  public final FileTree<FileT> fileTree() {
+    // simple double-checked locking
+    if (fileTree == null) {
+      synchronized (this) {
+        if (fileTree == null) {
+          long scanStartNanos = System.nanoTime();
+          FileTree<FileT> fileTree = scan();
+          log.info(
+              "Scanned {} in: {}. {} files. {}MB",
+              this,
+              elapsed(scanStartNanos),
+              NUMBER_FORMAT.format(fileTree.fileCount()),
+              NUMBER_FORMAT.format(fileTree.totalSize() / MEGA));
+          this.fileTree = fileTree;
+        }
+      }
+    }
+    return fileTree;
+  }
+
+  protected abstract FileTree<FileT> scan();
+}

--- a/file-backup-core/src/main/java/com/willmolloy/backup/DirectoryFiller.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/DirectoryFiller.java
@@ -1,0 +1,14 @@
+package com.willmolloy.backup;
+
+import java.util.function.Function;
+
+/**
+ * Used to fill in missing directories when building the {@link FileTree}.
+ *
+ * <p>Useful when directories/folders aren't scanned - e.g. AWS S3 ListObjects.
+ *
+ * @param <DirectoryT> type of directory produced
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+@FunctionalInterface
+public interface DirectoryFiller<DirectoryT extends File> extends Function<String, DirectoryT> {}

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -21,23 +21,26 @@ public interface FileTree<FileT extends File> {
     return get(relativePath).isPresent();
   }
 
-  /** Traverses the {@link FileTree} in a post-order manner. */
+  /** Traverses all nodes in a post-order manner. */
   Stream<FileT> postorder();
 
-  /** Traverses the leaves of the {@link FileTree}. Left to right. */
+  /** Traverses all leaves, left to right. */
   Stream<FileT> leaves();
 
-  /**
-   * Traverses the ancestors of the {@link FileTree}. From the parent of the given {@code file} to
-   * the root.
-   */
+  /** Traverses ancestors from the parent of the given {@code file} to the root. */
   Stream<FileT> ancestors(FileT file);
 
   /** Returns the subtree rooted at the given {@code file}. */
   FileTree<FileT> subtree(FileT file);
 
+  /** Count of files (where {@link File#isDirectory()} is {@code false}). */
   long fileCount();
 
+  /**
+   * Total size in bytes.
+   *
+   * @see File#size()
+   */
   long totalSize();
 
   /**

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -40,6 +40,26 @@ public interface FileTree<FileT extends File> {
 
   long totalSize();
 
+  /**
+   * Returns an instance of {@link FileTree.Builder}.
+   *
+   * @param root file which will be the root of the {@link FileTree}
+   */
+  static <FileT extends File> Builder<FileT> builder(FileT root) {
+    return builder(
+        root,
+        path -> {
+          throw new IllegalStateException("Directory Filler unexpected");
+        });
+  }
+
+  /**
+   * Returns an instance of {@link FileTree.Builder}.
+   *
+   * @param root file which will be the root of the {@link FileTree}
+   * @param directoryFiller {@link DirectoryFiller} to fill in missing directories during {@link
+   *     FileTree.Builder#insert}.
+   */
   static <FileT extends File> Builder<FileT> builder(
       FileT root, DirectoryFiller<FileT> directoryFiller) {
     return new TrieBasedFileTree.Builder<>(root, directoryFiller);

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -15,6 +15,10 @@ public interface FileTree<FileT extends File> {
 
   Optional<FileT> get(Path relativePath);
 
+  default boolean contains(Path relativePath) {
+    return get(relativePath).isPresent();
+  }
+
   Stream<FileT> postorder();
 
   Stream<FileT> leaves();

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 /**
  * Represents a {@link Location}s file tree.
  *
- * @see #builder()
+ * @see #builder
  * @param <FileT> type of file stored in this file tree
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
@@ -28,8 +28,9 @@ public interface FileTree<FileT extends File> {
 
   long totalSize();
 
-  static <FileT extends File> Builder<FileT> builder() {
-    return TrieBasedFileTree.builder();
+  static <FileT extends File> Builder<FileT> builder(
+      FileT root, Function<String, FileT> directoryFiller) {
+    return new TrieBasedFileTree.Builder<>(root, directoryFiller);
   }
 
   /**
@@ -38,13 +39,6 @@ public interface FileTree<FileT extends File> {
    * @param <FileT> type of file stored in the built file tree
    */
   interface Builder<FileT extends File> {
-
-    /**
-     * Fills in missing directories with the {@code directoryFiller}.
-     *
-     * @apiNote Useful for cases where directories are not scanned. E.g. AWS S3 ListObjects.
-     */
-    Builder<FileT> withDirectoryFiller(Function<String, FileT> directoryFiller);
 
     Builder<FileT> insert(FileT file);
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -1,5 +1,6 @@
 package com.willmolloy.backup;
 
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -25,7 +26,7 @@ public interface FileTree<FileT extends File> {
 
   Stream<FileT> ancestors(FileT file);
 
-  FileTree<FileT> subtree(FileT file);
+  FileTree<FileT> subtree(FileT file) throws NoSuchFileException;
 
   long fileCount();
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -2,7 +2,6 @@ package com.willmolloy.backup;
 
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -15,7 +14,7 @@ import java.util.stream.Stream;
  */
 public interface FileTree<FileT extends File> {
 
-  void forEach(Consumer<FileT> consumer);
+  Stream<FileT> preorder();
 
   Optional<FileT> get(Path relativePath);
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -2,7 +2,6 @@ package com.willmolloy.backup;
 
 import java.nio.file.Path;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -29,7 +28,7 @@ public interface FileTree<FileT extends File> {
   long totalSize();
 
   static <FileT extends File> Builder<FileT> builder(
-      FileT root, Function<String, FileT> directoryFiller) {
+      FileT root, DirectoryFiller<FileT> directoryFiller) {
     return new TrieBasedFileTree.Builder<>(root, directoryFiller);
   }
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -1,6 +1,5 @@
 package com.willmolloy.backup;
 
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -14,19 +13,28 @@ import java.util.stream.Stream;
  */
 public interface FileTree<FileT extends File> {
 
+  /** Lookup by {@link File#relativePath()}. */
   Optional<FileT> get(Path relativePath);
 
+  /** Lookup test by {@link File#relativePath()}. */
   default boolean contains(Path relativePath) {
     return get(relativePath).isPresent();
   }
 
+  /** Traverses the {@link FileTree} in a post-order manner. */
   Stream<FileT> postorder();
 
+  /** Traverses the leaves of the {@link FileTree}. Left to right. */
   Stream<FileT> leaves();
 
+  /**
+   * Traverses the ancestors of the {@link FileTree}. From the parent of the given {@code file} to
+   * the root.
+   */
   Stream<FileT> ancestors(FileT file);
 
-  FileTree<FileT> subtree(FileT file) throws NoSuchFileException;
+  /** Returns the subtree rooted at the given {@code file}. */
+  FileTree<FileT> subtree(FileT file);
 
   long fileCount();
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -16,7 +16,7 @@ public interface FileTree<FileT extends File> {
 
   Optional<FileT> get(Path relativePath);
 
-  Stream<FileT> preorder();
+  Stream<FileT> postorder();
 
   Stream<FileT> leaves();
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -18,11 +18,9 @@ public interface FileTree<FileT extends File> {
 
   Optional<FileT> get(Path relativePath);
 
-  boolean contains(Path relativePath);
+  Stream<FileT> ancestors(FileT file);
 
-  Stream<FileT> ancestors(Path relativePath);
-
-  Stream<FileT> descendants(Path relativePath);
+  Stream<FileT> descendants(FileT file);
 
   long fileCount();
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -14,15 +14,15 @@ import java.util.stream.Stream;
  */
 public interface FileTree<FileT extends File> {
 
+  Optional<FileT> get(Path relativePath);
+
   Stream<FileT> preorder();
 
   Stream<FileT> leaves();
 
-  Optional<FileT> get(Path relativePath);
-
   Stream<FileT> ancestors(FileT file);
 
-  Stream<FileT> descendants(FileT file);
+  FileTree<FileT> subtree(FileT file);
 
   long fileCount();
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/FileTree.java
@@ -16,6 +16,8 @@ public interface FileTree<FileT extends File> {
 
   Stream<FileT> preorder();
 
+  Stream<FileT> leaves();
+
   Optional<FileT> get(Path relativePath);
 
   Stream<FileT> ancestors(FileT file);

--- a/file-backup-core/src/main/java/com/willmolloy/backup/Location.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/Location.java
@@ -8,6 +8,6 @@ package com.willmolloy.backup;
  */
 public interface Location<FileT extends File> {
 
-  /** Scans the location's {@link FileTree}. */
-  FileTree<FileT> scan();
+  /** Returns the location's {@link FileTree}. */
+  FileTree<FileT> fileTree();
 }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/Location.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/Location.java
@@ -4,6 +4,7 @@ package com.willmolloy.backup;
  * {@link Backup} location (source or destination).
  *
  * @param <FileT> type of file stored in this location
+ * @see BaseLocation
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
 public interface Location<FileT extends File> {

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -6,10 +6,12 @@ import static java.util.function.Predicate.not;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.EntryMessage;
@@ -26,27 +28,23 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
 
   private final Trie<FileT> trie;
 
-  private TrieBasedFileTree(Trie<FileT> trie) {
+  TrieBasedFileTree(Trie<FileT> trie) {
     this.trie = requireNonNull(trie);
-  }
-
-  @Override
-  public Stream<FileT> preorder() {
-    return trie.root.stream().map(Trie.Node::file);
-  }
-
-  @Override
-  public Stream<FileT> leaves() {
-    return preorder().filter(this::isLeaf);
-  }
-
-  private boolean isLeaf(FileT file) {
-    return descendants(file).noneMatch(e -> true);
   }
 
   @Override
   public Optional<FileT> get(Path relativePath) {
     return trie.get(relativePath).map(Trie.Node::file);
+  }
+
+  @Override
+  public Stream<FileT> preorder() {
+    return trie.root.preorder().map(Trie.Node::file);
+  }
+
+  @Override
+  public Stream<FileT> leaves() {
+    return trie.root.preorder().filter(node -> node.children.isEmpty()).map(Trie.Node::file);
   }
 
   @Override
@@ -59,11 +57,10 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   @Override
-  public Stream<FileT> descendants(FileT file) {
-    return trie.get(file.relativePath()).stream()
-        .flatMap(Trie.Node::stream)
-        .skip(1)
-        .map(Trie.Node::file);
+  public FileTree<FileT> subtree(FileT file) {
+    return trie.get(file.relativePath())
+        .map(node -> new TrieBasedFileTree<>(new Trie<>(node)))
+        .orElseGet(() -> TrieBasedFileTree.<FileT>builder().build());
   }
 
   @Override
@@ -111,38 +108,32 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
    */
   private static final class Trie<FileT extends File> {
     private final Node<FileT> root;
-    private final Function<String, FileT> directoryFiller;
 
-    Trie(Function<String, FileT> directoryFiller) {
-      this.directoryFiller = directoryFiller;
-      if (directoryFiller == null) {
-        this.root = new Node<>(null, null);
-      } else {
-        this.root = new Node<>(null, requireNonNull(directoryFiller.apply("")));
-      }
+    private Trie(Node<FileT> root) {
+      this.root = requireNonNull(root);
     }
 
-    void insert(FileT file) {
+    private void insert(FileT file, @Nullable Function<String, FileT> directoryFiller) {
       Node<FileT> node = root;
-      StringBuilder path = new StringBuilder();
+      StringBuilder pathSoFar = new StringBuilder();
       for (String c : nameComponents(file.relativePath())) {
         Node<FileT> child = node.children.get(c);
-        path.append(c);
+        pathSoFar.append(c);
         if (child == null) {
           if (directoryFiller == null) {
-            child = new Node<>(node, null);
+            child = new Node<>(null, node);
           } else {
-            child = new Node<>(node, requireNonNull(directoryFiller.apply(path.toString())));
+            child = new Node<>(requireNonNull(directoryFiller.apply(pathSoFar.toString())), node);
           }
           node.children.put(c, child);
         }
         node = child;
-        path.append('/');
+        pathSoFar.append('/');
       }
       node.file = file;
     }
 
-    Optional<Node<FileT>> get(Path path) {
+    private Optional<Node<FileT>> get(Path path) {
       Node<FileT> node = root;
       for (String c : nameComponents(path)) {
         Node<FileT> child = node.children.get(c);
@@ -160,28 +151,28 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
      * @param <FileT> type of file stored in this node
      */
     private static final class Node<FileT extends File> {
-      private FileT file;
+      @Nullable private FileT file;
 
       // trie fields
-      private final Node<FileT> parent;
-      private final HashMap<String, Node<FileT>> children;
+      @Nullable private final Node<FileT> parent;
+      private final Map<String, Node<FileT>> children;
 
-      Node(Node<FileT> parent, FileT file) {
+      private Node(FileT file, Node<FileT> parent) {
+        this.file = file;
         this.parent = parent;
         this.children = new HashMap<>();
-        this.file = file;
       }
 
-      Stream<Node<FileT>> stream() {
-        return Stream.concat(Stream.of(this), children.values().stream().flatMap(Node::stream))
+      private Stream<Node<FileT>> preorder() {
+        return Stream.concat(Stream.of(this), children.values().stream().flatMap(Node::preorder))
             .filter(Node::containsData);
       }
 
-      boolean containsData() {
+      private boolean containsData() {
         return file != null;
       }
 
-      FileT file() {
+      private FileT file() {
         return file;
       }
 
@@ -221,26 +212,29 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
    * @param <FileT> type of file stored in the built file tree
    */
   static final class Builder<FileT extends File> implements FileTree.Builder<FileT> {
-
     private final Trie<FileT> trie;
+    @Nullable private final Function<String, FileT> directoryFiller;
 
-    private Builder(Trie<FileT> trie) {
+    private Builder(Trie<FileT> trie, @Nullable Function<String, FileT> directoryFiller) {
       this.trie = requireNonNull(trie);
+      this.directoryFiller = directoryFiller;
     }
 
     private Builder() {
-      this(new Trie<>(null));
+      this(new Trie<>(new Trie.Node<>(null, null)), null);
     }
 
     @Override
     public Builder<FileT> withDirectoryFiller(Function<String, FileT> directoryFiller) {
-      return new TrieBasedFileTree.Builder<>(new Trie<>(directoryFiller));
+      return new TrieBasedFileTree.Builder<>(
+          new Trie<>(new Trie.Node<>(requireNonNull(directoryFiller.apply("")), null)),
+          directoryFiller);
     }
 
     @Override
     public Builder<FileT> insert(FileT file) {
       EntryMessage m = log.traceEntry("insert({})", file);
-      trie.insert(file);
+      trie.insert(file, directoryFiller);
       return log.traceExit(m, this);
     }
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -36,6 +36,15 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   @Override
+  public Stream<FileT> leaves() {
+    return preorder().filter(this::isLeaf);
+  }
+
+  private boolean isLeaf(FileT file) {
+    return descendants(file).noneMatch(e -> true);
+  }
+
+  @Override
   public Optional<FileT> get(Path relativePath) {
     return trie.get(relativePath).map(Trie.Node::file);
   }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -4,6 +4,7 @@ import static com.willmolloy.backup.util.PathHelper.nameComponents;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
 
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
@@ -56,10 +57,10 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   @Override
-  public FileTree<FileT> subtree(FileT file) {
+  public FileTree<FileT> subtree(FileT file) throws NoSuchFileException {
     return trie.get(file.relativePath())
         .map(node -> new TrieBasedFileTree<>(new Trie<>(node)))
-        .orElseThrow();
+        .orElseThrow(() -> new NoSuchFileException(file.relativePath().toString()));
   }
 
   @Override

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -228,7 +228,6 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
 
     @Override
     public TrieBasedFileTree<FileT> build() {
-      // TODO post condition?
       return new TrieBasedFileTree<>(trie);
     }
   }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -8,7 +8,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
@@ -32,8 +31,8 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   @Override
-  public void forEach(Consumer<FileT> consumer) {
-    trie.root.stream().map(Trie.Node::file).forEach(consumer);
+  public Stream<FileT> preorder() {
+    return trie.root.stream().map(Trie.Node::file);
   }
 
   @Override
@@ -70,8 +69,8 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
     return files().mapToLong(File::size).sum();
   }
 
-  private Stream<? extends File> files() {
-    return trie.root.stream().map(Trie.Node::file).filter(not(File::isDirectory));
+  private Stream<FileT> files() {
+    return preorder().filter(not(File::isDirectory));
   }
 
   @Override

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -4,7 +4,6 @@ import static com.willmolloy.backup.util.PathHelper.nameComponents;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Predicate.not;
 
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -57,10 +56,11 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   @Override
-  public FileTree<FileT> subtree(FileT file) throws NoSuchFileException {
+  public FileTree<FileT> subtree(FileT file) {
     return trie.get(file.relativePath())
         .map(node -> new TrieBasedFileTree<>(new Trie<>(node)))
-        .orElseThrow(() -> new NoSuchFileException(file.relativePath().toString()));
+        // shouldn't get here... only if you did subtree.subtree
+        .orElseGet(() -> new TrieBasedFileTree.Builder<>(file, path -> null).build());
   }
 
   @Override

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
@@ -113,7 +112,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
       this.root = requireNonNull(root);
     }
 
-    private void insert(FileT file, Function<String, FileT> directoryFiller) {
+    private void insert(FileT file, DirectoryFiller<FileT> directoryFiller) {
       Node<FileT> node = root;
       StringBuilder pathSoFar = new StringBuilder(root.file.relativePath().toString());
       List<String> pathToNode =
@@ -212,9 +211,9 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
    */
   static final class Builder<FileT extends File> implements FileTree.Builder<FileT> {
     private final Trie<FileT> trie;
-    private final Function<String, FileT> directoryFiller;
+    private final DirectoryFiller<FileT> directoryFiller;
 
-    Builder(FileT root, Function<String, FileT> directoryFiller) {
+    Builder(FileT root, DirectoryFiller<FileT> directoryFiller) {
       this.trie = new Trie<>(new Trie.Node<>(root, null));
       this.directoryFiller = requireNonNull(directoryFiller);
     }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -129,12 +129,10 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
                     last
                         ? new Node<>(file, currentNode)
                         : new Node<>(directoryFiller.apply(pathSoFar.toString()), currentNode));
-        if (last) {
-          return;
-        }
         pathSoFar.append('/');
       }
-            node.file = file;
+      // no need to set Node.file here; assuming only leaves are inserted or parent dirs are
+      // inserted first (i.e. in a pre-order manner)
     }
 
     private Optional<Node<FileT>> get(Path path) {
@@ -156,7 +154,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
      * @param <FileT> type of file stored in this node
      */
     private static final class Node<FileT extends File> {
-      private FileT file;
+      private final FileT file;
 
       // trie fields
       @Nullable private final Node<FileT> parent;

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -53,7 +53,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   public Stream<FileT> ancestors(FileT file) {
     return trie.get(file.relativePath()).stream()
         .flatMap(node -> Stream.iterate(node.parent, parent -> parent.parent))
-        .takeWhile(node -> node != trie.root)
+        .takeWhile(node -> node != trie.root.parent)
         .filter(Trie.Node::containsData)
         .map(Trie.Node::file);
   }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -41,13 +41,8 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   @Override
-  public boolean contains(Path relativePath) {
-    return trie.get(relativePath).isPresent();
-  }
-
-  @Override
-  public Stream<FileT> ancestors(Path relativePath) {
-    return trie.get(relativePath).stream()
+  public Stream<FileT> ancestors(FileT file) {
+    return trie.get(file.relativePath()).stream()
         .flatMap(node -> Stream.iterate(node.parent, parent -> parent.parent))
         .takeWhile(node -> node != trie.root)
         .filter(Trie.Node::containsData)
@@ -55,8 +50,11 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   @Override
-  public Stream<FileT> descendants(Path relativePath) {
-    return trie.get(relativePath).stream().flatMap(Trie.Node::stream).skip(1).map(Trie.Node::file);
+  public Stream<FileT> descendants(FileT file) {
+    return trie.get(file.relativePath()).stream()
+        .flatMap(Trie.Node::stream)
+        .skip(1)
+        .map(Trie.Node::file);
   }
 
   @Override

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -27,7 +27,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
 
   private final Trie<FileT> trie;
 
-  TrieBasedFileTree(Trie<FileT> trie) {
+  private TrieBasedFileTree(Trie<FileT> trie) {
     this.trie = requireNonNull(trie);
   }
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -6,6 +6,7 @@ import static java.util.function.Predicate.not;
 
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -38,13 +39,13 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   @Override
-  public Stream<FileT> preorder() {
-    return trie.root.preorder().map(Trie.Node::file);
+  public Stream<FileT> postorder() {
+    return trie.root.postorder().map(Trie.Node::file);
   }
 
   @Override
   public Stream<FileT> leaves() {
-    return trie.root.preorder().filter(node -> node.children.isEmpty()).map(Trie.Node::file);
+    return trie.root.postorder().filter(node -> node.children.isEmpty()).map(Trie.Node::file);
   }
 
   @Override
@@ -74,7 +75,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   }
 
   private Stream<FileT> files() {
-    return preorder().filter(not(File::isDirectory));
+    return postorder().filter(not(File::isDirectory));
   }
 
   @Override
@@ -115,8 +116,10 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
 
     private void insert(FileT file, @Nullable Function<String, FileT> directoryFiller) {
       Node<FileT> node = root;
+      // TODO broken when inserting into subtree... but that isn't used
       StringBuilder pathSoFar = new StringBuilder();
-      for (String c : nameComponents(file.relativePath())) {
+      List<String> pathToNode = nameComponents(file.relativePath());
+      for (String c : pathToNode) {
         Node<FileT> child = node.children.get(c);
         pathSoFar.append(c);
         if (child == null) {
@@ -135,7 +138,11 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
 
     private Optional<Node<FileT>> get(Path path) {
       Node<FileT> node = root;
-      for (String c : nameComponents(path)) {
+      List<String> pathToNode =
+          root.file == null
+              ? nameComponents(path)
+              : nameComponents(root.file.relativePath().relativize(path));
+      for (String c : pathToNode) {
         Node<FileT> child = node.children.get(c);
         if (child == null) {
           return Optional.empty();
@@ -163,8 +170,8 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
         this.children = new HashMap<>();
       }
 
-      private Stream<Node<FileT>> preorder() {
-        return Stream.concat(Stream.of(this), children.values().stream().flatMap(Node::preorder))
+      private Stream<Node<FileT>> postorder() {
+        return Stream.concat(children.values().stream().flatMap(Node::postorder), Stream.of(this))
             .filter(Node::containsData);
       }
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -15,7 +15,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.EntryMessage;
 
 /**
  * {@link FileTree} implemented via {@linkplain Trie trie data structure}.
@@ -61,7 +60,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
   public FileTree<FileT> subtree(FileT file) {
     return trie.get(file.relativePath())
         .map(node -> new TrieBasedFileTree<>(new Trie<>(node)))
-        .orElseGet(() -> TrieBasedFileTree.<FileT>builder().build());
+        .orElseThrow();
   }
 
   @Override
@@ -114,23 +113,25 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
       this.root = requireNonNull(root);
     }
 
-    private void insert(FileT file, @Nullable Function<String, FileT> directoryFiller) {
+    private void insert(FileT file, Function<String, FileT> directoryFiller) {
       Node<FileT> node = root;
       // TODO broken when inserting into subtree... but that isn't used
       StringBuilder pathSoFar = new StringBuilder();
       List<String> pathToNode = nameComponents(file.relativePath());
-      for (String c : pathToNode) {
-        Node<FileT> child = node.children.get(c);
-        pathSoFar.append(c);
-        if (child == null) {
-          if (directoryFiller == null) {
-            child = new Node<>(null, node);
-          } else {
-            child = new Node<>(requireNonNull(directoryFiller.apply(pathSoFar.toString())), node);
-          }
-          node.children.put(c, child);
-        }
-        node = child;
+      for (int i = 0; i < pathToNode.size(); i++) {
+        pathSoFar.append(pathToNode.get(i));
+        Node<FileT> currentNode = node;
+        boolean last = i == pathToNode.size() - 1;
+        node =
+            node.children.computeIfAbsent(
+                pathToNode.get(i),
+                k -> {
+                  if (last) {
+                    return new Node<>(file, currentNode);
+                  } else {
+                    return new Node<>(directoryFiller.apply(pathSoFar.toString()), currentNode);
+                  }
+                });
         pathSoFar.append('/');
       }
       node.file = file;
@@ -158,14 +159,14 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
      * @param <FileT> type of file stored in this node
      */
     private static final class Node<FileT extends File> {
-      @Nullable private FileT file;
+      private FileT file;
 
       // trie fields
       @Nullable private final Node<FileT> parent;
       private final Map<String, Node<FileT>> children;
 
       private Node(FileT file, Node<FileT> parent) {
-        this.file = file;
+        this.file = requireNonNull(file);
         this.parent = parent;
         this.children = new HashMap<>();
       }
@@ -209,10 +210,6 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
     }
   }
 
-  static <FileT extends File> TrieBasedFileTree.Builder<FileT> builder() {
-    return new TrieBasedFileTree.Builder<>();
-  }
-
   /**
    * {@link FileTree.Builder} implementation for {@link TrieBasedFileTree}.
    *
@@ -220,33 +217,23 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
    */
   static final class Builder<FileT extends File> implements FileTree.Builder<FileT> {
     private final Trie<FileT> trie;
-    @Nullable private final Function<String, FileT> directoryFiller;
+    private final Function<String, FileT> directoryFiller;
 
-    private Builder(Trie<FileT> trie, @Nullable Function<String, FileT> directoryFiller) {
-      this.trie = requireNonNull(trie);
-      this.directoryFiller = directoryFiller;
-    }
-
-    private Builder() {
-      this(new Trie<>(new Trie.Node<>(null, null)), null);
-    }
-
-    @Override
-    public Builder<FileT> withDirectoryFiller(Function<String, FileT> directoryFiller) {
-      return new TrieBasedFileTree.Builder<>(
-          new Trie<>(new Trie.Node<>(requireNonNull(directoryFiller.apply("")), null)),
-          directoryFiller);
+    Builder(FileT root, Function<String, FileT> directoryFiller) {
+      this.trie = new Trie<>(new Trie.Node<>(root, null));
+      this.directoryFiller = requireNonNull(directoryFiller);
     }
 
     @Override
     public Builder<FileT> insert(FileT file) {
-      EntryMessage m = log.traceEntry("insert({})", file);
+      log.debug("insert({})", file);
       trie.insert(file, directoryFiller);
-      return log.traceExit(m, this);
+      return this;
     }
 
     @Override
     public TrieBasedFileTree<FileT> build() {
+      // TODO post condition?
       return new TrieBasedFileTree<>(trie);
     }
   }

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -6,7 +6,7 @@ import static java.util.function.Predicate.not;
 
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -163,7 +163,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
       private Node(FileT file, Node<FileT> parent) {
         this.file = requireNonNull(file);
         this.parent = parent;
-        this.children = new HashMap<>();
+        this.children = new LinkedHashMap<>();
       }
 
       private Stream<Node<FileT>> postorder() {

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -51,7 +51,6 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
     return trie.get(file.relativePath()).stream()
         .flatMap(node -> Stream.iterate(node.parent, parent -> parent.parent))
         .takeWhile(node -> node != trie.root.parent)
-        .filter(Trie.Node::containsData)
         .map(Trie.Node::file);
   }
 
@@ -145,7 +144,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
         }
         node = child;
       }
-      return node.containsData() ? Optional.of(node) : Optional.empty();
+      return Optional.of(node);
     }
 
     /**
@@ -167,12 +166,7 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
       }
 
       private Stream<Node<FileT>> postorder() {
-        return Stream.concat(children.values().stream().flatMap(Node::postorder), Stream.of(this))
-            .filter(Node::containsData);
-      }
-
-      private boolean containsData() {
-        return file != null;
+        return Stream.concat(children.values().stream().flatMap(Node::postorder), Stream.of(this));
       }
 
       private FileT file() {

--- a/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/TrieBasedFileTree.java
@@ -115,9 +115,9 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
 
     private void insert(FileT file, Function<String, FileT> directoryFiller) {
       Node<FileT> node = root;
-      // TODO broken when inserting into subtree... but that isn't used
-      StringBuilder pathSoFar = new StringBuilder();
-      List<String> pathToNode = nameComponents(file.relativePath());
+      StringBuilder pathSoFar = new StringBuilder(root.file.relativePath().toString());
+      List<String> pathToNode =
+          nameComponents(root.file.relativePath().relativize(file.relativePath()));
       for (int i = 0; i < pathToNode.size(); i++) {
         pathSoFar.append(pathToNode.get(i));
         Node<FileT> currentNode = node;
@@ -125,24 +125,21 @@ final class TrieBasedFileTree<FileT extends File> implements FileTree<FileT> {
         node =
             node.children.computeIfAbsent(
                 pathToNode.get(i),
-                k -> {
-                  if (last) {
-                    return new Node<>(file, currentNode);
-                  } else {
-                    return new Node<>(directoryFiller.apply(pathSoFar.toString()), currentNode);
-                  }
-                });
+                k ->
+                    last
+                        ? new Node<>(file, currentNode)
+                        : new Node<>(directoryFiller.apply(pathSoFar.toString()), currentNode));
+        if (last) {
+          return;
+        }
         pathSoFar.append('/');
       }
-      node.file = file;
+            node.file = file;
     }
 
     private Optional<Node<FileT>> get(Path path) {
       Node<FileT> node = root;
-      List<String> pathToNode =
-          root.file == null
-              ? nameComponents(path)
-              : nameComponents(root.file.relativePath().relativize(path));
+      List<String> pathToNode = nameComponents(root.file.relativePath().relativize(path));
       for (String c : pathToNode) {
         Node<FileT> child = node.children.get(c);
         if (child == null) {

--- a/file-backup-core/src/main/java/com/willmolloy/backup/util/Md5Helper.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/util/Md5Helper.java
@@ -8,7 +8,6 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.EntryMessage;
 
 /**
  * Helper for computing MD5 hash.
@@ -25,9 +24,9 @@ public final class Md5Helper {
   }
 
   private static byte[] md5(Path file) throws IOException {
-    EntryMessage m = log.traceEntry("md5({})", file);
+    log.debug("md5({})", file);
     try (InputStream inputStream = Files.newInputStream(file)) {
-      return log.traceExit(m, DigestUtils.md5(inputStream));
+      return DigestUtils.md5(inputStream);
     }
   }
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/util/StreamHelper.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/util/StreamHelper.java
@@ -38,7 +38,6 @@ public final class StreamHelper {
                     .toList();
               }
             };
-
     return StreamSupport.stream(result.spliterator(), false);
   }
 

--- a/file-backup-core/src/main/java/com/willmolloy/backup/util/StreamHelper.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/util/StreamHelper.java
@@ -1,0 +1,46 @@
+package com.willmolloy.backup.util;
+
+import static com.willmolloy.backup.util.Preconditions.require;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Helper methods for {@link Stream}.
+ *
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+public final class StreamHelper {
+
+  /** Splits the given {@code stream} into chunks of size at most {@code size}. */
+  public static <T> Stream<List<T>> chunk(Stream<T> stream, int size) {
+    require(size >= 0);
+    Iterator<T> input = stream.iterator();
+    Iterable<List<T>> result =
+        () ->
+            new Iterator<>() {
+              @Override
+              public boolean hasNext() {
+                return input.hasNext();
+              }
+
+              @SuppressFBWarnings(
+                  value = "IT_NO_SUCH_ELEMENT",
+                  justification = "Returns empty list")
+              @Override
+              public List<T> next() {
+                return IntStream.iterate(0, i -> i < size && input.hasNext(), i -> i + 1)
+                    .mapToObj(i -> input.next())
+                    .toList();
+              }
+            };
+
+    return StreamSupport.stream(result.spliterator(), false);
+  }
+
+  private StreamHelper() {}
+}

--- a/file-backup-core/src/main/java/com/willmolloy/backup/util/TimeHelper.java
+++ b/file-backup-core/src/main/java/com/willmolloy/backup/util/TimeHelper.java
@@ -1,0 +1,17 @@
+package com.willmolloy.backup.util;
+
+import java.time.Duration;
+
+/**
+ * Helper methods for {@link java.time}.
+ *
+ * @author <a href=https://willmolloy.com>Will Molloy</a>
+ */
+public final class TimeHelper {
+
+  public static Duration elapsed(long startNanos) {
+    return Duration.ofNanos(System.nanoTime() - startNanos);
+  }
+
+  private TimeHelper() {}
+}

--- a/file-backup-core/src/main/resources/log4j2.xml
+++ b/file-backup-core/src/main/resources/log4j2.xml
@@ -11,6 +11,6 @@
       <AppenderRef ref="console"/>
     </Root>
 
-    <Logger name="com.willmolloy" level="debug"/>
+    <Logger name="com.willmolloy" level="info"/>
   </Loggers>
 </Configuration>

--- a/file-backup-core/src/main/resources/log4j2.xml
+++ b/file-backup-core/src/main/resources/log4j2.xml
@@ -11,6 +11,6 @@
       <AppenderRef ref="console"/>
     </Root>
 
-    <Logger name="com.willmolloy" level="info"/>
+    <Logger name="com.willmolloy" level="debug"/>
   </Loggers>
 </Configuration>

--- a/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
@@ -45,8 +45,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnlyOnSource_createsFileOnDestination() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().build());
     when(mockBackup.put(any())).thenReturn(true);
 
     // When
@@ -60,8 +60,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnSourceAndDestination_andNotSame_updatesFileOnDestination() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().insert(differentFile("A")).build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(differentFile("A")).build());
     when(mockBackup.put(any())).thenReturn(true);
 
     // When
@@ -75,8 +75,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnSourceAndDestination_andSame_skipsUpdate() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
 
     // When
     boolean result = BackupRunner.run(mockBackup);
@@ -89,8 +89,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnlyOnDestination_deletesFileFromDestination() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
     // When
@@ -104,8 +104,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnDestinationAndSource_skipsDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
 
     // When
     boolean result = BackupRunner.run(mockBackup);
@@ -118,8 +118,8 @@ class BackupRunnerTest {
   @Test
   void whenCreateFails_countsFailedCreate() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().build());
     when(mockBackup.put(any())).thenReturn(false);
 
     // When
@@ -133,8 +133,8 @@ class BackupRunnerTest {
   @Test
   void whenUpdateFails_countsFailedUpdate() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().insert(differentFile("A")).build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(differentFile("A")).build());
     when(mockBackup.put(any())).thenReturn(false);
 
     // When
@@ -148,8 +148,8 @@ class BackupRunnerTest {
   @Test
   void whenDeleteFails_countsFailedDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
     when(mockBackup.delete(any())).thenReturn(false);
 
     // When
@@ -164,8 +164,8 @@ class BackupRunnerTest {
   void whenChildExists_skipsPut() {
     // Given
     when(mockSource.scan())
-        .thenReturn(FileTree.builder().insert(file("A")).insert(file("A/B")).build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().build());
+        .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B")).build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().build());
     when(mockBackup.put(any())).thenReturn(true);
 
     // When
@@ -181,8 +181,8 @@ class BackupRunnerTest {
   void whenGrandChildExists_skipsPut() {
     // Given
     when(mockSource.scan())
-        .thenReturn(FileTree.builder().insert(file("A")).insert(file("A/B/C")).build());
-    when(mockDest.scan()).thenReturn(FileTree.builder().build());
+        .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B/C")).build());
+    when(mockDest.scan()).thenReturn(fileTreeBuilder().build());
     when(mockBackup.put(any())).thenReturn(true);
 
     // When
@@ -197,9 +197,9 @@ class BackupRunnerTest {
   @Test
   void whenParentExists_skipsDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().build());
     when(mockDest.scan())
-        .thenReturn(FileTree.builder().insert(file("A")).insert(file("A/B")).build());
+        .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
     // When
@@ -214,9 +214,9 @@ class BackupRunnerTest {
   @Test
   void whenGrandParentExists_skipsDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().build());
     when(mockDest.scan())
-        .thenReturn(FileTree.builder().insert(file("A")).insert(file("A/B/C")).build());
+        .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B/C")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
     // When
@@ -231,9 +231,9 @@ class BackupRunnerTest {
   @Test
   void whenParentExistsButParentInSource_stillDeletes() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
+    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
     when(mockDest.scan())
-        .thenReturn(FileTree.builder().insert(file("A")).insert(file("A/B")).build());
+        .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
     // When
@@ -248,9 +248,11 @@ class BackupRunnerTest {
   @Test
   void whenGrandParentExistsButGrandParentInSource_stillDeletes() {
     // Given
-    when(mockSource.scan()).thenReturn(FileTree.builder().insert(file("A")).build());
+    when(mockSource.scan())
+        .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B")).build());
     when(mockDest.scan())
-        .thenReturn(FileTree.builder().insert(file("A")).insert(file("A/B/C")).build());
+        .thenReturn(
+            fileTreeBuilder().insert(file("A")).insert(file("A/B")).insert(file("A/B/C")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
     // When
@@ -260,6 +262,14 @@ class BackupRunnerTest {
     assertThat(result).isTrue();
     verify(mockBackup, never()).delete(file("A"));
     verify(mockBackup).delete(file("A/B/C"));
+  }
+
+  private static FileTree.Builder<File> fileTreeBuilder() {
+    return FileTree.builder(directory(""), BackupRunnerTest::directory);
+  }
+
+  private static File directory(String path) {
+    return new TestFile(path, Path.of(path), 0, true);
   }
 
   private static File file(String path) {

--- a/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/BackupRunnerTest.java
@@ -35,8 +35,8 @@ class BackupRunnerTest {
 
   @AfterEach
   void tearDown() {
-    verify(mockSource).scan();
-    verify(mockDest).scan();
+    verify(mockSource).fileTree();
+    verify(mockDest).fileTree();
     verifyNoMoreInteractions(mockSource);
     verifyNoMoreInteractions(mockDest);
     verifyNoMoreInteractions(mockBackup);
@@ -45,8 +45,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnlyOnSource_createsFileOnDestination() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().build());
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().build());
     when(mockBackup.put(any())).thenReturn(true);
 
     // When
@@ -60,8 +60,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnSourceAndDestination_andNotSame_updatesFileOnDestination() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(differentFile("A")).build());
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().insert(differentFile("A")).build());
     when(mockBackup.put(any())).thenReturn(true);
 
     // When
@@ -75,8 +75,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnSourceAndDestination_andSame_skipsUpdate() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
 
     // When
     boolean result = BackupRunner.run(mockBackup);
@@ -89,8 +89,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnlyOnDestination_deletesFileFromDestination() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
     // When
@@ -104,8 +104,8 @@ class BackupRunnerTest {
   @Test
   void whenFileOnDestinationAndSource_skipsDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
 
     // When
     boolean result = BackupRunner.run(mockBackup);
@@ -118,8 +118,8 @@ class BackupRunnerTest {
   @Test
   void whenCreateFails_countsFailedCreate() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().build());
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().build());
     when(mockBackup.put(any())).thenReturn(false);
 
     // When
@@ -133,8 +133,8 @@ class BackupRunnerTest {
   @Test
   void whenUpdateFails_countsFailedUpdate() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(differentFile("A")).build());
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().insert(differentFile("A")).build());
     when(mockBackup.put(any())).thenReturn(false);
 
     // When
@@ -148,8 +148,8 @@ class BackupRunnerTest {
   @Test
   void whenDeleteFails_countsFailedDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
     when(mockBackup.delete(any())).thenReturn(false);
 
     // When
@@ -163,9 +163,9 @@ class BackupRunnerTest {
   @Test
   void whenChildExists_skipsPut() {
     // Given
-    when(mockSource.scan())
+    when(mockSource.fileTree())
         .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B")).build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().build());
     when(mockBackup.put(any())).thenReturn(true);
 
     // When
@@ -180,9 +180,9 @@ class BackupRunnerTest {
   @Test
   void whenGrandChildExists_skipsPut() {
     // Given
-    when(mockSource.scan())
+    when(mockSource.fileTree())
         .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B/C")).build());
-    when(mockDest.scan()).thenReturn(fileTreeBuilder().build());
+    when(mockDest.fileTree()).thenReturn(fileTreeBuilder().build());
     when(mockBackup.put(any())).thenReturn(true);
 
     // When
@@ -197,8 +197,8 @@ class BackupRunnerTest {
   @Test
   void whenParentExists_skipsDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().build());
-    when(mockDest.scan())
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().build());
+    when(mockDest.fileTree())
         .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
@@ -214,8 +214,8 @@ class BackupRunnerTest {
   @Test
   void whenGrandParentExists_skipsDelete() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().build());
-    when(mockDest.scan())
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().build());
+    when(mockDest.fileTree())
         .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B/C")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
@@ -231,8 +231,8 @@ class BackupRunnerTest {
   @Test
   void whenParentExistsButParentInSource_stillDeletes() {
     // Given
-    when(mockSource.scan()).thenReturn(fileTreeBuilder().insert(file("A")).build());
-    when(mockDest.scan())
+    when(mockSource.fileTree()).thenReturn(fileTreeBuilder().insert(file("A")).build());
+    when(mockDest.fileTree())
         .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B")).build());
     when(mockBackup.delete(any())).thenReturn(true);
 
@@ -248,9 +248,9 @@ class BackupRunnerTest {
   @Test
   void whenGrandParentExistsButGrandParentInSource_stillDeletes() {
     // Given
-    when(mockSource.scan())
+    when(mockSource.fileTree())
         .thenReturn(fileTreeBuilder().insert(file("A")).insert(file("A/B")).build());
-    when(mockDest.scan())
+    when(mockDest.fileTree())
         .thenReturn(
             fileTreeBuilder().insert(file("A")).insert(file("A/B")).insert(file("A/B/C")).build());
     when(mockBackup.delete(any())).thenReturn(true);

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -3,11 +3,7 @@ package com.willmolloy.backup;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
-import com.google.common.collect.Sets;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
@@ -19,53 +15,61 @@ import org.junit.jupiter.api.Test;
 class TrieBasedFileTreeTest {
 
   @Test
-  void forEach_visitsEachNodeExactlyOnce() {
+  void preorder_returnsNodesInPreorder() {
     // Given
-    Set<File> expected =
-        Set.of(
+    TrieBasedFileTree<File> fileTree =
+        TrieBasedFileTree.builder()
+            .insert(file("A"))
+            .insert(file("A/B"))
+            .insert(file("A/B/C"))
+            .insert(file("D"))
+            .insert(file("D/E"))
+            .insert(file("D/F"))
+            .insert(file("X/Y/Z"))
+            .build();
+
+    // Then
+    assertThat(fileTree.preorder())
+        .containsExactly(
             file("A"),
             file("A/B"),
             file("A/B/C"),
             file("D"),
             file("D/E"),
             file("D/F"),
-            file("X/Y/Z"));
-    TrieBasedFileTree.Builder<File> builder = TrieBasedFileTree.builder();
-    expected.forEach(builder::insert);
-    TrieBasedFileTree<File> fileTree = builder.build();
-
-    // When
-    List<File> actual = new ArrayList<>();
-    fileTree.forEach(actual::add);
-
-    // Then
-    assertThat(actual).containsExactlyElementsIn(expected);
+            file("X/Y/Z"))
+        .inOrder();
   }
 
   @Test
-  void forEach_withDirectoryFiller_visitsEachNodeExactlyOnceIncludingMissingDirs() {
+  void preorder_withDirectoryFiller_returnsNodesIncludingMissingDirsInPreorder() {
     // Given
-    Set<File> expected =
-        Set.of(
+    TrieBasedFileTree<File> fileTree =
+        TrieBasedFileTree.builder()
+            .withDirectoryFiller(directoryFiller())
+            .insert(file("A"))
+            .insert(file("A/B"))
+            .insert(file("A/B/C"))
+            .insert(file("D"))
+            .insert(file("D/E"))
+            .insert(file("D/F"))
+            .insert(file("X/Y/Z"))
+            .build();
+
+    // Then
+    assertThat(fileTree.preorder())
+        .containsExactly(
+            directory(""),
             file("A"),
             file("A/B"),
             file("A/B/C"),
             file("D"),
             file("D/E"),
             file("D/F"),
-            file("X/Y/Z"));
-    TrieBasedFileTree.Builder<File> builder =
-        TrieBasedFileTree.builder().withDirectoryFiller(directoryFiller());
-    expected.forEach(builder::insert);
-    TrieBasedFileTree<File> fileTree = builder.build();
-
-    // When
-    List<File> actual = new ArrayList<>();
-    fileTree.forEach(actual::add);
-
-    // Then
-    Set<File> missingDirs = Set.of(directory(""), directory("X"), directory("X/Y"));
-    assertThat(actual).containsExactlyElementsIn(Sets.union(expected, missingDirs));
+            directory("X"),
+            directory("X/Y"),
+            file("X/Y/Z"))
+        .inOrder();
   }
 
   @Test

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -2,9 +2,7 @@ package com.willmolloy.backup;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
@@ -101,6 +99,7 @@ class TrieBasedFileTreeTest {
 
   @Test
   void ancestors_returnsAncestorsIncludingMissingDirs() {
+    // Given
     TrieBasedFileTree<File> fileTree =
         new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(directory("A"))
@@ -109,6 +108,8 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
+
+    // Then
     assertThat(fileTree.ancestors(file("A/B/C/D")))
         .containsExactly(directory("A/B/C"), directory("A/B"), directory("A"), directory(""))
         .inOrder();
@@ -116,6 +117,7 @@ class TrieBasedFileTreeTest {
 
   @Test
   void ancestors_whenNodeNotInTree_empty() {
+    // Given
     TrieBasedFileTree<File> fileTree =
         new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(directory("A"))
@@ -124,11 +126,13 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
+
+    // Then
     assertThat(fileTree.ancestors(file("X/Y/Z"))).isEmpty();
   }
 
   @Test
-  void subtree_returnsSubtreeRootedAtGivenNodeIncludingMissingDirs() throws NoSuchFileException {
+  void subtree_returnsSubtreeRootedAtGivenNodeIncludingMissingDirs() {
     // Given
     TrieBasedFileTree<File> fileTree =
         new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
@@ -154,10 +158,19 @@ class TrieBasedFileTreeTest {
                 .insert(directory("A/B/C/D/X/Y"))
                 .insert(file("A/B/C/D/X/Y/Z"))
                 .build());
+    // verify ancestors ends at the new root
+    assertThat(subtree.ancestors(file("A/B/C/D/X/Y/Z")))
+        .containsExactly(
+            directory("A/B/C/D/X/Y"),
+            directory("A/B/C/D/X"),
+            directory("A/B/C/D"),
+            directory("A/B/C"))
+        .inOrder();
   }
 
   @Test
-  void subtree_whenFileNotInTree_throws() {
+  void subtree_whenFileNotInTree_returnsTreeContainingJustThatFile() {
+    // Given
     TrieBasedFileTree<File> fileTree =
         new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(directory("A"))
@@ -166,10 +179,14 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    File notInTree = directory("X/Y/Z");
-    NoSuchFileException thrown =
-        assertThrows(NoSuchFileException.class, () -> fileTree.subtree(notInTree));
-    assertThat(thrown).hasMessageThat().isEqualTo(notInTree.relativePath().toString());
+    File notInTree = file("X/Y/Z");
+
+    // When
+    FileTree<File> subtree = fileTree.subtree(notInTree);
+
+    // Then
+    assertThat(subtree)
+        .isEqualTo(new TrieBasedFileTree.Builder<>(file("X/Y/Z"), path -> null).build());
   }
 
   private static File file(String path) {

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -4,8 +4,8 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.util.NoSuchElementException;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -128,7 +128,7 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void subtree_returnsSubtreeRootedAtGivenNodeIncludingMissingDirs() {
+  void subtree_returnsSubtreeRootedAtGivenNodeIncludingMissingDirs() throws NoSuchFileException {
     // Given
     TrieBasedFileTree<File> fileTree =
         new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
@@ -157,7 +157,7 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void subtree_whenNodeNotInTree_throws() {
+  void subtree_whenFileNotInTree_throws() {
     TrieBasedFileTree<File> fileTree =
         new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(directory("A"))
@@ -166,7 +166,10 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThrows(NoSuchElementException.class, () -> fileTree.subtree(directory("X/Y/Z")));
+    File notInTree = directory("X/Y/Z");
+    NoSuchFileException thrown =
+        assertThrows(NoSuchFileException.class, () -> fileTree.subtree(notInTree));
+    assertThat(thrown).hasMessageThat().isEqualTo(notInTree.relativePath().toString());
   }
 
   private static File file(String path) {

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -59,7 +59,7 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void preorder_returnsNodesInPreorder() {
+  void postorder_returnsNodesInPostorder() {
     // Given
     TrieBasedFileTree<File> fileTree =
         TrieBasedFileTree.builder()
@@ -73,20 +73,20 @@ class TrieBasedFileTreeTest {
             .build();
 
     // Then
-    assertThat(fileTree.preorder())
+    assertThat(fileTree.postorder())
         .containsExactly(
-            file("A"),
-            file("A/B"),
             file("A/B/C"),
-            file("D"),
+            file("A/B"),
+            file("A"),
             file("D/E"),
             file("D/F"),
+            file("D"),
             file("X/Y/Z"))
         .inOrder();
   }
 
   @Test
-  void preorder_withDirectoryFiller_returnsNodesIncludingMissingDirsInPreorder() {
+  void postorder_withDirectoryFiller_returnsNodesIncludingMissingDirsInPostorder() {
     // Given
     TrieBasedFileTree<File> fileTree =
         TrieBasedFileTree.builder()
@@ -101,23 +101,23 @@ class TrieBasedFileTreeTest {
             .build();
 
     // Then
-    assertThat(fileTree.preorder())
+    assertThat(fileTree.postorder())
         .containsExactly(
-            directory(""),
-            file("A"),
-            file("A/B"),
             file("A/B/C"),
-            file("D"),
+            file("A/B"),
+            file("A"),
             file("D/E"),
             file("D/F"),
-            directory("X"),
+            file("D"),
+            file("X/Y/Z"),
             directory("X/Y"),
-            file("X/Y/Z"))
+            directory("X"),
+            directory(""))
         .inOrder();
   }
 
   @Test
-  void leaves_returnsLeaves() {
+  void leaves_returnsLeavesLeftToRight() {
     // Given
     TrieBasedFileTree<File> fileTree =
         TrieBasedFileTree.builder()
@@ -196,11 +196,12 @@ class TrieBasedFileTreeTest {
     FileTree<File> subtree = fileTree.subtree(directory("A/B/C"));
 
     // Then
-    // building the subtree complicates the implementation, so testing via pre-order
-    assertThat(subtree.preorder())
+    // building the subtree complicates the implementation, so testing via post-order/ancestors
+    assertThat(subtree.postorder())
         .containsExactly(
-            directory("A/B/C"), file("A/B/C/D/E"), file("A/B/C/D/F"), file("A/B/C/D/X/Y/Z"))
+            file("A/B/C/D/E"), file("A/B/C/D/F"), file("A/B/C/D/X/Y/Z"), directory("A/B/C"))
         .inOrder();
+    assertThat(subtree.ancestors(file("A/B/C/D/X/Y/Z"))).containsExactly(directory("A/B/C"));
   }
 
   @Test
@@ -234,16 +235,18 @@ class TrieBasedFileTreeTest {
     FileTree<File> subtree = fileTree.subtree(directory("A/B/C/D"));
 
     // Then
-    // building the subtree complicates the implementation, so testing via pre-order
-    assertThat(subtree.preorder())
+    // building the subtree complicates the implementation, so testing via post-order
+    assertThat(subtree.postorder())
         .containsExactly(
-            directory("A/B/C/D"),
             file("A/B/C/D/E"),
             file("A/B/C/D/F"),
-            directory("A/B/C/D/X"),
+            file("A/B/C/D/X/Y/Z"),
             directory("A/B/C/D/X/Y"),
-            file("A/B/C/D/X/Y/Z"))
+            directory("A/B/C/D/X"),
+            directory("A/B/C/D"))
         .inOrder();
+    assertThat(subtree.ancestors(file("A/B/C/D/X/Y/Z")))
+        .containsExactly(directory("A/B/C/D/X/Y"), directory("A/B/C/D/X"), directory("A/B/C/D"));
   }
 
   @Test

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -73,6 +73,26 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
+  void leaves_returnsLeaves() {
+    // Given
+    TrieBasedFileTree<File> fileTree =
+        TrieBasedFileTree.builder()
+            .insert(file("A"))
+            .insert(file("A/B"))
+            .insert(file("A/B/C"))
+            .insert(file("D"))
+            .insert(file("D/E"))
+            .insert(file("D/F"))
+            .insert(file("X/Y/Z"))
+            .build();
+
+    // Then
+    assertThat(fileTree.leaves())
+        .containsExactly(file("A/B/C"), file("D/E"), file("D/F"), file("X/Y/Z"))
+        .inOrder();
+  }
+
+  @Test
   void get_whenNodePresent_present() {
     File expected = file("A/B");
     TrieBasedFileTree<File> fileTree =

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -117,50 +117,6 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void contains_whenNodePresent_true() {
-    File expected = file("A/B");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .insert(file("A"))
-            .insert(expected)
-            .insert(file("A/B/C"))
-            .build();
-    assertThat(fileTree.contains(expected.relativePath())).isTrue();
-  }
-
-  @Test
-  void contains_whenNodeAbsent_false() {
-    File notExpected = file("A/B");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder().insert(file("A")).insert(file("A/B/C")).build();
-    assertThat(fileTree.contains(notExpected.relativePath())).isFalse();
-  }
-
-  @Test
-  void contains_withDirectoryFiller_whenMissingDirFilledIn_true() {
-    File expected = file("A/B");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
-            .insert(file("A"))
-            .insert(file("A/B/C"))
-            .build();
-    assertThat(fileTree.contains(expected.relativePath())).isTrue();
-  }
-
-  @Test
-  void contains_withDirectoryFiller_whenMissingDirNotFilledIn_false() {
-    File notExpected = file("A/B/C/D");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
-            .insert(file("A"))
-            .insert(file("A/B/C"))
-            .build();
-    assertThat(fileTree.contains(notExpected.relativePath())).isFalse();
-  }
-
-  @Test
   void ancestors_returnsAncestors() {
     TrieBasedFileTree<File> fileTree =
         TrieBasedFileTree.builder()
@@ -170,7 +126,7 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.ancestors(Path.of("A/B/C/D/E")))
+    assertThat(fileTree.ancestors(file("A/B/C/D/E")))
         .containsExactly(directory("A/B/C"), directory("A"))
         .inOrder();
   }
@@ -185,7 +141,7 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.ancestors(Path.of("A/B/C/D"))).isEmpty();
+    assertThat(fileTree.ancestors(file("A/B/C/D"))).isEmpty();
   }
 
   @Test
@@ -199,7 +155,7 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.ancestors(Path.of("A/B/C/D/E")))
+    assertThat(fileTree.ancestors(file("A/B/C/D/E")))
         .containsExactly(directory("A/B/C/D"), directory("A/B/C"), directory("A/B"), directory("A"))
         .inOrder();
   }
@@ -214,7 +170,7 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.descendants(Path.of("A/B/C")))
+    assertThat(fileTree.descendants(file("A/B/C")))
         .containsExactly(file("A/B/C/D/E"), file("A/B/C/D/F"), file("A/B/C/D/X/Y/Z"))
         .inOrder();
   }
@@ -229,7 +185,7 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.descendants(Path.of("A/B/C/D"))).isEmpty();
+    assertThat(fileTree.descendants(file("A/B/C/D"))).isEmpty();
   }
 
   @Test
@@ -243,7 +199,7 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.descendants(Path.of("A/B/C")))
+    assertThat(fileTree.descendants(file("A/B/C")))
         .containsExactly(
             directory("A/B/C/D"),
             file("A/B/C/D/E"),

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -176,7 +176,12 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
     assertThat(fileTree.ancestors(file("A/B/C/D/E")))
-        .containsExactly(directory("A/B/C/D"), directory("A/B/C"), directory("A/B"), directory("A"))
+        .containsExactly(
+            directory("A/B/C/D"),
+            directory("A/B/C"),
+            directory("A/B"),
+            directory("A"),
+            directory(""))
         .inOrder();
   }
 

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -15,6 +15,50 @@ import org.junit.jupiter.api.Test;
 class TrieBasedFileTreeTest {
 
   @Test
+  void get_whenNodePresent_present() {
+    File expected = file("A/B");
+    TrieBasedFileTree<File> fileTree =
+        TrieBasedFileTree.builder()
+            .insert(file("A"))
+            .insert(expected)
+            .insert(file("A/B/C"))
+            .build();
+    assertThat(fileTree.get(expected.relativePath())).hasValue(expected);
+  }
+
+  @Test
+  void get_whenNodeAbsent_empty() {
+    File notExpected = file("A/B");
+    TrieBasedFileTree<File> fileTree =
+        TrieBasedFileTree.builder().insert(file("A")).insert(file("A/B/C")).build();
+    assertThat(fileTree.get(notExpected.relativePath())).isEmpty();
+  }
+
+  @Test
+  void get_withDirectoryFiller_whenMissingDirFilledIn_present() {
+    File expected = file("A/B");
+    TrieBasedFileTree<File> fileTree =
+        TrieBasedFileTree.builder()
+            .withDirectoryFiller(directoryFiller())
+            .insert(file("A"))
+            .insert(file("A/B/C"))
+            .build();
+    assertThat(fileTree.get(expected.relativePath())).hasValue(directory("A/B"));
+  }
+
+  @Test
+  void get_withDirectoryFiller_whenMissingDirNotFilledIn_empty() {
+    File notExpected = file("A/B/C/D");
+    TrieBasedFileTree<File> fileTree =
+        TrieBasedFileTree.builder()
+            .withDirectoryFiller(directoryFiller())
+            .insert(file("A"))
+            .insert(file("A/B/C"))
+            .build();
+    assertThat(fileTree.get(notExpected.relativePath())).isEmpty();
+  }
+
+  @Test
   void preorder_returnsNodesInPreorder() {
     // Given
     TrieBasedFileTree<File> fileTree =
@@ -93,50 +137,6 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void get_whenNodePresent_present() {
-    File expected = file("A/B");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .insert(file("A"))
-            .insert(expected)
-            .insert(file("A/B/C"))
-            .build();
-    assertThat(fileTree.get(expected.relativePath())).hasValue(expected);
-  }
-
-  @Test
-  void get_whenNodeAbsent_empty() {
-    File notExpected = file("A/B");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder().insert(file("A")).insert(file("A/B/C")).build();
-    assertThat(fileTree.get(notExpected.relativePath())).isEmpty();
-  }
-
-  @Test
-  void get_withDirectoryFiller_whenMissingDirFilledIn_present() {
-    File expected = file("A/B");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
-            .insert(file("A"))
-            .insert(file("A/B/C"))
-            .build();
-    assertThat(fileTree.get(expected.relativePath())).hasValue(directory("A/B"));
-  }
-
-  @Test
-  void get_withDirectoryFiller_whenMissingDirNotFilledIn_empty() {
-    File notExpected = file("A/B/C/D");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
-            .insert(file("A"))
-            .insert(file("A/B/C"))
-            .build();
-    assertThat(fileTree.get(notExpected.relativePath())).isEmpty();
-  }
-
-  @Test
   void ancestors_returnsAncestors() {
     TrieBasedFileTree<File> fileTree =
         TrieBasedFileTree.builder()
@@ -175,18 +175,36 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.ancestors(file("A/B/C/D/E")))
+    assertThat(fileTree.ancestors(file("A/B/C/D")))
+        .containsExactly(directory("A/B/C"), directory("A/B"), directory("A"), directory(""))
+        .inOrder();
+  }
+
+  @Test
+  void subtree_returnsSubtreeRootedAtGivenNode() {
+    // Given
+    TrieBasedFileTree<File> fileTree =
+        TrieBasedFileTree.builder()
+            .insert(directory("A"))
+            .insert(directory("A/B/C"))
+            .insert(file("A/B/C/D/E"))
+            .insert(file("A/B/C/D/F"))
+            .insert(file("A/B/C/D/X/Y/Z"))
+            .build();
+
+    // When
+    FileTree<File> subtree = fileTree.subtree(directory("A/B/C"));
+
+    // Then
+    // building the subtree complicates the implementation, so testing via pre-order
+    assertThat(subtree.preorder())
         .containsExactly(
-            directory("A/B/C/D"),
-            directory("A/B/C"),
-            directory("A/B"),
-            directory("A"),
-            directory(""))
+            directory("A/B/C"), file("A/B/C/D/E"), file("A/B/C/D/F"), file("A/B/C/D/X/Y/Z"))
         .inOrder();
   }
 
   @Test
-  void descendants_returnsDescendants() {
+  void subtree_whenNodeNotInTree_empty() {
     TrieBasedFileTree<File> fileTree =
         TrieBasedFileTree.builder()
             .insert(directory("A"))
@@ -195,26 +213,13 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.descendants(file("A/B/C")))
-        .containsExactly(file("A/B/C/D/E"), file("A/B/C/D/F"), file("A/B/C/D/X/Y/Z"))
-        .inOrder();
+    assertThat(fileTree.subtree(directory("A/B/C/D")))
+        .isEqualTo(TrieBasedFileTree.builder().build());
   }
 
   @Test
-  void descendants_whenNodeNotInTree_empty() {
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .insert(directory("A"))
-            .insert(directory("A/B/C"))
-            .insert(file("A/B/C/D/E"))
-            .insert(file("A/B/C/D/F"))
-            .insert(file("A/B/C/D/X/Y/Z"))
-            .build();
-    assertThat(fileTree.descendants(file("A/B/C/D"))).isEmpty();
-  }
-
-  @Test
-  void descendants_withDirectoryFiller_returnsDescendantsIncludingMissingDirs() {
+  void subtree_withDirectoryFiller_returnsSubtreeRootedAtGivenNodeIncludingMissingDirs() {
+    // Given
     TrieBasedFileTree<File> fileTree =
         TrieBasedFileTree.builder()
             .withDirectoryFiller(directoryFiller())
@@ -224,7 +229,13 @@ class TrieBasedFileTreeTest {
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.descendants(file("A/B/C")))
+
+    // When
+    FileTree<File> subtree = fileTree.subtree(directory("A/B/C/D"));
+
+    // Then
+    // building the subtree complicates the implementation, so testing via pre-order
+    assertThat(subtree.preorder())
         .containsExactly(
             directory("A/B/C/D"),
             file("A/B/C/D/E"),

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -2,8 +2,10 @@ package com.willmolloy.backup;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
+import java.util.NoSuchElementException;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
@@ -15,10 +17,10 @@ import org.junit.jupiter.api.Test;
 class TrieBasedFileTreeTest {
 
   @Test
-  void get_whenNodePresent_present() {
+  void get_whenNodeInTree_present() {
     File expected = file("A/B");
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(file("A"))
             .insert(expected)
             .insert(file("A/B/C"))
@@ -27,19 +29,10 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void get_whenNodeAbsent_empty() {
-    File notExpected = file("A/B");
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder().insert(file("A")).insert(file("A/B/C")).build();
-    assertThat(fileTree.get(notExpected.relativePath())).isEmpty();
-  }
-
-  @Test
-  void get_withDirectoryFiller_whenMissingDirFilledIn_present() {
+  void get_whenMissingDirFilledIn_present() {
     File expected = file("A/B");
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(file("A"))
             .insert(file("A/B/C"))
             .build();
@@ -47,11 +40,10 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void get_withDirectoryFiller_whenMissingDirNotFilledIn_empty() {
+  void get_whenNodeNotInTree_empty() {
     File notExpected = file("A/B/C/D");
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(file("A"))
             .insert(file("A/B/C"))
             .build();
@@ -59,38 +51,10 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void postorder_returnsNodesInPostorder() {
+  void postorder_returnsNodesIncludingMissingDirsInPostorder() {
     // Given
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .insert(file("A"))
-            .insert(file("A/B"))
-            .insert(file("A/B/C"))
-            .insert(file("D"))
-            .insert(file("D/E"))
-            .insert(file("D/F"))
-            .insert(file("X/Y/Z"))
-            .build();
-
-    // Then
-    assertThat(fileTree.postorder())
-        .containsExactly(
-            file("A/B/C"),
-            file("A/B"),
-            file("A"),
-            file("D/E"),
-            file("D/F"),
-            file("D"),
-            file("X/Y/Z"))
-        .inOrder();
-  }
-
-  @Test
-  void postorder_withDirectoryFiller_returnsNodesIncludingMissingDirsInPostorder() {
-    // Given
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(file("A"))
             .insert(file("A/B"))
             .insert(file("A/B/C"))
@@ -120,7 +84,7 @@ class TrieBasedFileTreeTest {
   void leaves_returnsLeavesLeftToRight() {
     // Given
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(file("A"))
             .insert(file("A/B"))
             .insert(file("A/B/C"))
@@ -137,38 +101,9 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void ancestors_returnsAncestors() {
+  void ancestors_returnsAncestorsIncludingMissingDirs() {
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .insert(directory("A"))
-            .insert(directory("A/B/C"))
-            .insert(file("A/B/C/D/E"))
-            .insert(file("A/B/C/D/F"))
-            .insert(file("A/B/C/D/X/Y/Z"))
-            .build();
-    assertThat(fileTree.ancestors(file("A/B/C/D/E")))
-        .containsExactly(directory("A/B/C"), directory("A"))
-        .inOrder();
-  }
-
-  @Test
-  void ancestors_whenNodeNotInTree_empty() {
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .insert(directory("A"))
-            .insert(directory("A/B/C"))
-            .insert(file("A/B/C/D/E"))
-            .insert(file("A/B/C/D/F"))
-            .insert(file("A/B/C/D/X/Y/Z"))
-            .build();
-    assertThat(fileTree.ancestors(file("A/B/C/D"))).isEmpty();
-  }
-
-  @Test
-  void ancestors_withDirectoryFiller_returnsAncestorsIncludingMissingDirs() {
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(directory("A"))
             .insert(directory("A/B/C"))
             .insert(file("A/B/C/D/E"))
@@ -181,49 +116,23 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void subtree_returnsSubtreeRootedAtGivenNode() {
-    // Given
+  void ancestors_whenNodeNotInTree_empty() {
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(directory("A"))
             .insert(directory("A/B/C"))
             .insert(file("A/B/C/D/E"))
             .insert(file("A/B/C/D/F"))
             .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-
-    // When
-    FileTree<File> subtree = fileTree.subtree(directory("A/B/C"));
-
-    // Then
-    // building the subtree complicates the implementation, so testing via post-order/ancestors
-    assertThat(subtree.postorder())
-        .containsExactly(
-            file("A/B/C/D/E"), file("A/B/C/D/F"), file("A/B/C/D/X/Y/Z"), directory("A/B/C"))
-        .inOrder();
-    assertThat(subtree.ancestors(file("A/B/C/D/X/Y/Z"))).containsExactly(directory("A/B/C"));
+    assertThat(fileTree.ancestors(file("X/Y/Z"))).isEmpty();
   }
 
   @Test
-  void subtree_whenNodeNotInTree_empty() {
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .insert(directory("A"))
-            .insert(directory("A/B/C"))
-            .insert(file("A/B/C/D/E"))
-            .insert(file("A/B/C/D/F"))
-            .insert(file("A/B/C/D/X/Y/Z"))
-            .build();
-    assertThat(fileTree.subtree(directory("A/B/C/D")))
-        .isEqualTo(TrieBasedFileTree.builder().build());
-  }
-
-  @Test
-  void subtree_withDirectoryFiller_returnsSubtreeRootedAtGivenNodeIncludingMissingDirs() {
+  void subtree_returnsSubtreeRootedAtGivenNodeIncludingMissingDirs() {
     // Given
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .withDirectoryFiller(directoryFiller())
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(directory("A"))
             .insert(directory("A/B/C"))
             .insert(file("A/B/C/D/E"))
@@ -235,7 +144,7 @@ class TrieBasedFileTreeTest {
     FileTree<File> subtree = fileTree.subtree(directory("A/B/C/D"));
 
     // Then
-    // building the subtree complicates the implementation, so testing via post-order
+    // building the subtree complicates the implementation, so testing via post-order/ancestors
     assertThat(subtree.postorder())
         .containsExactly(
             file("A/B/C/D/E"),
@@ -250,33 +159,16 @@ class TrieBasedFileTreeTest {
   }
 
   @Test
-  void fileCount_countsFiles() {
+  void subtree_whenNodeNotInTree_throws() {
     TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
             .insert(directory("A"))
-            .insert(directory("A/B"))
-            .insert(file("A/B/C"))
-            .insert(file("A/B/D"))
-            .insert(directory("X"))
-            .insert(directory("X/Y"))
-            .insert(file("X/Y/Z"))
+            .insert(directory("A/B/C"))
+            .insert(file("A/B/C/D/E"))
+            .insert(file("A/B/C/D/F"))
+            .insert(file("A/B/C/D/X/Y/Z"))
             .build();
-    assertThat(fileTree.fileCount()).isEqualTo(3);
-  }
-
-  @Test
-  void totalSize_sumsFileSize() {
-    TrieBasedFileTree<File> fileTree =
-        TrieBasedFileTree.builder()
-            .insert(directory("A"))
-            .insert(directory("A/B"))
-            .insert(file("A/B/C"))
-            .insert(file("A/B/D"))
-            .insert(directory("X"))
-            .insert(directory("X/Y"))
-            .insert(file("X/Y/Z"))
-            .build();
-    assertThat(fileTree.totalSize()).isEqualTo(6);
+    assertThrows(NoSuchElementException.class, () -> fileTree.subtree(directory("X/Y/Z")));
   }
 
   private static File file(String path) {
@@ -288,7 +180,7 @@ class TrieBasedFileTreeTest {
   }
 
   private static Function<String, File> directoryFiller() {
-    return path -> directory(path);
+    return TrieBasedFileTreeTest::directory;
   }
 
   private record TestFile(String uri, Path relativePath, long size, boolean isDirectory)

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.file.Path;
 import java.util.NoSuchElementException;
-import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -178,7 +177,7 @@ class TrieBasedFileTreeTest {
     return new TestFile(path, Path.of(path), 0, true);
   }
 
-  private static Function<String, File> directoryFiller() {
+  private static DirectoryFiller<File> directoryFiller() {
     return TrieBasedFileTreeTest::directory;
   }
 

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -189,6 +189,36 @@ class TrieBasedFileTreeTest {
         .isEqualTo(new TrieBasedFileTree.Builder<>(file("X/Y/Z"), path -> null).build());
   }
 
+  @Test
+  void fileCount_countsFiles() {
+    TrieBasedFileTree<File> fileTree =
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
+            .insert(directory("A"))
+            .insert(directory("A/B"))
+            .insert(file("A/B/C"))
+            .insert(file("A/B/D"))
+            .insert(directory("X"))
+            .insert(directory("X/Y"))
+            .insert(file("X/Y/Z"))
+            .build();
+    assertThat(fileTree.fileCount()).isEqualTo(3);
+  }
+
+  @Test
+  void totalSize_sumsFileSize() {
+    TrieBasedFileTree<File> fileTree =
+        new TrieBasedFileTree.Builder<>(directory(""), directoryFiller())
+            .insert(directory("A"))
+            .insert(directory("A/B"))
+            .insert(file("A/B/C"))
+            .insert(file("A/B/D"))
+            .insert(directory("X"))
+            .insert(directory("X/Y"))
+            .insert(file("X/Y/Z"))
+            .build();
+    assertThat(fileTree.totalSize()).isEqualTo(6);
+  }
+
   private static File file(String path) {
     return new TestFile(path, Path.of(path), 2, false);
   }

--- a/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
+++ b/file-backup-core/src/test/java/com/willmolloy/backup/TrieBasedFileTreeTest.java
@@ -141,21 +141,20 @@ class TrieBasedFileTreeTest {
             .build();
 
     // When
-    FileTree<File> subtree = fileTree.subtree(directory("A/B/C/D"));
+    FileTree<File> subtree = fileTree.subtree(directory("A/B/C"));
 
     // Then
-    // building the subtree complicates the implementation, so testing via post-order/ancestors
-    assertThat(subtree.postorder())
-        .containsExactly(
-            file("A/B/C/D/E"),
-            file("A/B/C/D/F"),
-            file("A/B/C/D/X/Y/Z"),
-            directory("A/B/C/D/X/Y"),
-            directory("A/B/C/D/X"),
-            directory("A/B/C/D"))
-        .inOrder();
-    assertThat(subtree.ancestors(file("A/B/C/D/X/Y/Z")))
-        .containsExactly(directory("A/B/C/D/X/Y"), directory("A/B/C/D/X"), directory("A/B/C/D"));
+    assertThat(subtree)
+        .isEqualTo(
+            // null directoryFiller, otherwise it isn't tested!
+            new TrieBasedFileTree.Builder<>(directory("A/B/C"), path -> null)
+                .insert(directory("A/B/C/D"))
+                .insert(file("A/B/C/D/E"))
+                .insert(file("A/B/C/D/F"))
+                .insert(directory("A/B/C/D/X"))
+                .insert(directory("A/B/C/D/X/Y"))
+                .insert(file("A/B/C/D/X/Y/Z"))
+                .build());
   }
 
   @Test

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -57,6 +57,7 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
       }
       return true;
     } catch (FileAlreadyExistsException e) {
+      // TODO if we do the deletes first, we won't end up in these scenarios? Good to be safe?
       // failed to create directory since it already exists as a file
       FileSystem fs = destination.root().getFileSystem();
       Path badPath = fs.getPath(e.getFile());

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -7,13 +7,11 @@ import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystem;
-import java.nio.file.FileVisitResult;
-import java.nio.file.FileVisitor;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -37,13 +35,9 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
   public boolean put(LocalFile sourceFile) {
     Path sourcePath = sourceFile.fullPath();
     Path destPath = destination.root().resolve(sourceFile.relativePath());
-    return robustCopy(sourcePath, destPath);
-  }
-
-  private boolean robustCopy(Path sourcePath, Path destPath) {
     try {
       return createParentDirs(sourcePath, destPath) && doCopy(sourcePath, destPath);
-    } catch (IOException e) {
+    } catch (Exception e) {
       log.error("Error copying: [{}] -> [{}]", sourcePath, destPath, e);
       return false;
     }
@@ -59,27 +53,28 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
     } catch (FileAlreadyExistsException e) {
       // TODO if we do the deletes first, we won't end up in these scenarios? But good to be safe?
       // failed to create directory since it already exists as a file
-      FileSystem fs = destination.root().getFileSystem();
-      Path badPath = fs.getPath(e.getFile());
       log.warn(
-          "Error copying: [{}] -> [{}]. Deleting file [{}] to allow creation of directories first",
+          "Error copying: [{}] -> [{}]. Deleting file to allow creation of directories first",
           sourcePath,
           destPath,
-          badPath,
           e);
-      return robustDelete(badPath) && createParentDirs(sourcePath, destPath);
+      FileSystem fs = destination.root().getFileSystem();
+      Path badPath = destination.root().relativize(fs.getPath(e.getFile()));
+      return delete(getDestFile(badPath)) && createParentDirs(sourcePath, destPath);
     } catch (NoSuchFileException e) {
       // same as above, except its thrown when the parent already exists as a file
       // (see https://stackoverflow.com/a/76278968/6122976)
-      FileSystem fs = destination.root().getFileSystem();
-      Path badPath = fs.getPath(e.getFile()).getParent();
       log.warn(
-          "Error copying: [{}] -> [{}]. Deleting file [{}] to allow creation of directories first",
+          "Error copying: [{}] -> [{}]. Deleting file to allow creation of directories first",
           sourcePath,
           destPath,
-          badPath,
           e);
-      return robustDelete(badPath) && createParentDirs(sourcePath, destPath);
+      FileSystem fs = destination.root().getFileSystem();
+      // for some reason e.getFile here is in absolute form, so take that into account
+      // TODO what if the jdk changes this behaviour? create a 'safe relativize' method?
+      Path badPath =
+          destination.root().toAbsolutePath().relativize(fs.getPath(e.getFile()).getParent());
+      return delete(getDestFile(badPath)) && createParentDirs(sourcePath, destPath);
     }
   }
 
@@ -102,65 +97,46 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
           sourcePath,
           destPath,
           e);
-      return robustDelete(destPath) && doCopy(sourcePath, destPath);
+      FileSystem fs = destination.root().getFileSystem();
+      Path badPath = destination.root().relativize(fs.getPath(e.getFile()));
+      return delete(getDestFile(badPath)) && doCopy(sourcePath, destPath);
     }
+  }
+
+  private LocalFile getDestFile(Path relativePath) {
+    return destination
+        .scan()
+        .get(relativePath)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Path [%s] not in destination file tree".formatted(relativePath)));
   }
 
   @Override
   public boolean delete(LocalFile destFile) {
-    return robustDelete(destFile.fullPath());
-  }
-
-  private boolean robustDelete(Path destPath) {
+    AtomicBoolean allDeleted = new AtomicBoolean(true);
     try {
-      // TODO redundant to walk FileTree we already scanned? (subtree -> postorder)
-      Files.walkFileTree(destPath, new RecursiveDelete());
-      log.info("Deleted: [{}]", destPath);
-      return true;
+      destination
+          .scan()
+          .subtree(destFile)
+          .postorder()
+          .map(LocalFile::fullPath)
+          .forEach(
+              destPath -> {
+                try {
+                  Files.delete(destPath);
+                  log.info("Deleted: [{}]", destPath);
+                } catch (NoSuchFileException e) {
+                  log.debug("Already deleted: [{}]", destPath, e);
+                } catch (Exception e) {
+                  log.error("Error deleting: [{}]", destPath, e);
+                  allDeleted.set(false);
+                }
+              });
     } catch (NoSuchFileException e) {
-      log.debug("Already deleted: [{}]", destPath, e);
-      return true;
-    } catch (IOException e) {
-      log.error("Error deleting: [{}]", destPath, e);
-      return false;
+      log.debug("Already deleted: [{}]", destFile, e);
     }
-  }
-
-  private static final class RecursiveDelete implements FileVisitor<Path> {
-    @Override
-    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attributes) {
-      return FileVisitResult.CONTINUE;
-    }
-
-    @Override
-    public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
-      Files.deleteIfExists(file);
-      return FileVisitResult.CONTINUE;
-    }
-
-    @Override
-    public FileVisitResult visitFileFailed(Path file, IOException e) throws IOException {
-      if (e instanceof NoSuchFileException) {
-        log.debug("Already deleted file: [{}]", file, e);
-        return FileVisitResult.CONTINUE;
-      } else {
-        log.error("Error visiting file: [{}]", file, e);
-        throw e;
-      }
-    }
-
-    @Override
-    public FileVisitResult postVisitDirectory(Path dir, IOException e) throws IOException {
-      if (e != null) {
-        if (e instanceof NoSuchFileException) {
-          log.debug("Already deleted directory: [{}]", dir, e);
-          return FileVisitResult.CONTINUE;
-        }
-        log.error("Error visiting directory: [{}]", dir, e);
-        throw e;
-      }
-      Files.deleteIfExists(dir);
-      return FileVisitResult.CONTINUE;
-    }
+    return allDeleted.get();
   }
 }

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -135,8 +135,9 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
                   allDeleted.set(false);
                 }
               });
-    } catch (NoSuchFileException e) {
-      log.debug("Already deleted: [{}]", destFile, e);
+    } catch (Exception e) {
+      log.error("Error deleting: [{}]", destFile.uri(), e);
+      return false;
     }
     return allDeleted.get();
   }

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -117,6 +117,7 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
   public boolean delete(LocalFile destFile) {
     AtomicBoolean allDeleted = new AtomicBoolean(true);
     try {
+      // TODO cache scan
       destination
           .scan()
           .subtree(destFile)

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -51,7 +51,7 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
       }
       return true;
     } catch (FileAlreadyExistsException e) {
-      // TODO if we do the deletes first, we won't end up in these scenarios? But good to be safe?
+      // TODO if we do the deletes first, we won't end up in these scenarios? Good to be safe?
       // failed to create directory since it already exists as a file
       log.warn(
           "Error copying: [{}] -> [{}]. Deleting file to allow creation of directories first",

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -117,7 +117,6 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
   public boolean delete(LocalFile destFile) {
     AtomicBoolean allDeleted = new AtomicBoolean(true);
     try {
-      // TODO cache scan
       destination
           .fileTree()
           .subtree(destFile)

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -112,7 +112,7 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
 
   private boolean robustDelete(Path destPath) {
     try {
-      // TODO redundant to walk FileTree we already scanned?
+      // TODO redundant to walk FileTree we already scanned? (descendants -> postorder)
       Files.walkFileTree(destPath, new RecursiveDelete());
       log.info("Deleted: [{}]", destPath);
       return true;

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -105,7 +105,7 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
 
   private LocalFile getDestFile(Path relativePath) {
     return destination
-        .scan()
+        .fileTree()
         .get(relativePath)
         .orElseThrow(
             () ->
@@ -119,7 +119,7 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
     try {
       // TODO cache scan
       destination
-          .scan()
+          .fileTree()
           .subtree(destFile)
           .postorder()
           .map(LocalFile::fullPath)

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalBackup.java
@@ -57,7 +57,7 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
       }
       return true;
     } catch (FileAlreadyExistsException e) {
-      // TODO if we do the deletes first, we won't end up in these scenarios? Good to be safe?
+      // TODO if we do the deletes first, we won't end up in these scenarios? But good to be safe?
       // failed to create directory since it already exists as a file
       FileSystem fs = destination.root().getFileSystem();
       Path badPath = fs.getPath(e.getFile());
@@ -113,7 +113,7 @@ final class LocalBackup extends BaseBackup<LocalFile, LocalFile> {
 
   private boolean robustDelete(Path destPath) {
     try {
-      // TODO redundant to walk FileTree we already scanned? (descendants -> postorder)
+      // TODO redundant to walk FileTree we already scanned? (subtree -> postorder)
       Files.walkFileTree(destPath, new RecursiveDelete());
       log.info("Deleted: [{}]", destPath);
       return true;

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalFile.java
@@ -6,7 +6,6 @@ import static java.util.Objects.requireNonNull;
 import com.willmolloy.backup.BaseFile;
 import com.willmolloy.backup.File;
 import java.io.IOException;
-import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -37,11 +36,6 @@ public final class LocalFile extends BaseFile {
   public static LocalFile fromPath(LocalStorage localStorage, Path path) throws IOException {
     return fromAttributes(
         localStorage, path, Files.readAttributes(path, BasicFileAttributes.class));
-  }
-
-  static LocalFile directoryFiller(LocalStorage localStorage, String relativePath) {
-    FileSystem fs = localStorage.root().getFileSystem();
-    return new LocalFile(localStorage, fs.getPath(relativePath), true, 0, 0);
   }
 
   private final LocalStorage localStorage;

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -39,7 +39,10 @@ public final class LocalStorage implements Location<LocalFile> {
     try {
       FileTree.Builder<LocalFile> builder =
           FileTree.builder(
-              LocalFile.fromPath(this, rootDir), path -> LocalFile.directoryFiller(this, path));
+              LocalFile.fromPath(this, rootDir),
+              path -> {
+                throw new IllegalStateException("Directory Filler unnecessary");
+              });
       BiConsumer<Path, BasicFileAttributes> consumer =
           (path, attributes) -> {
             if (path == rootDir) {

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -38,8 +38,8 @@ public final class LocalStorage implements Location<LocalFile> {
     log.info("Scanning directory: [{}]", rootDir);
     try {
       FileTree.Builder<LocalFile> builder =
-          FileTree.<LocalFile>builder()
-              .withDirectoryFiller(path -> LocalFile.directoryFiller(this, path));
+          FileTree.builder(
+              LocalFile.fromPath(this, rootDir), path -> LocalFile.directoryFiller(this, path));
       BiConsumer<Path, BasicFileAttributes> consumer =
           (path, attributes) -> {
             if (path == rootDir) {

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -37,12 +37,7 @@ public final class LocalStorage implements Location<LocalFile> {
   public FileTree<LocalFile> scan() {
     log.info("Scanning directory: [{}]", rootDir);
     try {
-      FileTree.Builder<LocalFile> builder =
-          FileTree.builder(
-              LocalFile.fromPath(this, rootDir),
-              path -> {
-                throw new IllegalStateException("Directory Filler unnecessary");
-              });
+      FileTree.Builder<LocalFile> builder = FileTree.builder(LocalFile.fromPath(this, rootDir));
       BiConsumer<Path, BasicFileAttributes> consumer =
           (path, attributes) -> {
             if (path == rootDir) {

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -35,7 +35,6 @@ public final class LocalStorage extends BaseLocation<LocalFile> {
 
   @Override
   protected FileTree<LocalFile> scan() {
-    log.info("Scanning directory: [{}]", rootDir);
     try {
       FileTree.Builder<LocalFile> builder = FileTree.builder(LocalFile.fromPath(this, rootDir));
       BiConsumer<Path, BasicFileAttributes> consumer =

--- a/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
+++ b/file-backup-local/src/main/java/com/willmolloy/backup/local/LocalStorage.java
@@ -3,8 +3,8 @@ package com.willmolloy.backup.local;
 import static com.willmolloy.backup.util.Preconditions.require;
 import static java.util.Objects.requireNonNull;
 
+import com.willmolloy.backup.BaseLocation;
 import com.willmolloy.backup.FileTree;
-import com.willmolloy.backup.Location;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.AccessDeniedException;
@@ -22,7 +22,7 @@ import org.apache.logging.log4j.Logger;
  *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-public final class LocalStorage implements Location<LocalFile> {
+public final class LocalStorage extends BaseLocation<LocalFile> {
 
   private static final Logger log = LogManager.getLogger();
 
@@ -34,7 +34,7 @@ public final class LocalStorage implements Location<LocalFile> {
   }
 
   @Override
-  public FileTree<LocalFile> scan() {
+  protected FileTree<LocalFile> scan() {
     log.info("Scanning directory: [{}]", rootDir);
     try {
       FileTree.Builder<LocalFile> builder = FileTree.builder(LocalFile.fromPath(this, rootDir));

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalFileTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalFileTest.java
@@ -205,17 +205,4 @@ class LocalFileTest {
             IllegalArgumentException.class, () -> LocalFile.fromAttributes(storage, path, null));
     assertThat(thrown).hasMessageThat().isEqualTo("Requires path [A] to be under root [root]");
   }
-
-  @Test
-  void directoryFiller() {
-    // Given
-    LocalFile directoryFiller = LocalFile.directoryFiller(storage, "A/B/C");
-
-    // Then
-    assertThat(directoryFiller.uri()).isEqualTo(storage.root().resolve("A/B/C").toString());
-    assertThat(directoryFiller.relativePath()).isEqualTo(fs.getPath("A/B/C"));
-    assertThat(directoryFiller.isDirectory()).isEqualTo(true);
-    assertThat(directoryFiller.size()).isEqualTo(0);
-    assertThat(directoryFiller.lastModified()).isEqualTo(0);
-  }
 }

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
@@ -65,8 +65,7 @@ class LocalStorageTest {
     // Then
     assertThat(scan)
         .isEqualTo(
-            // null directoryFiller, otherwise it isn't tested!
-            FileTree.builder(LocalFile.fromPath(sut, sut.root()), path -> null)
+            FileTree.builder(LocalFile.fromPath(sut, sut.root()))
                 .insert(LocalFile.fromPath(sut, root.resolve("A")))
                 .insert(LocalFile.fromPath(sut, root.resolve("B")))
                 .insert(LocalFile.fromPath(sut, root.resolve("C")))

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
@@ -60,7 +60,7 @@ class LocalStorageTest {
     Files.createFile(root.resolve("X/Y/Z"));
 
     // When
-    FileTree<LocalFile> scan = sut.scan();
+    FileTree<LocalFile> scan = sut.fileTree();
 
     // Then
     assertThat(scan)

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
@@ -65,6 +65,7 @@ class LocalStorageTest {
     // Then
     assertThat(scan)
         .isEqualTo(
+            // null directoryFiller, otherwise it isn't tested!
             FileTree.builder(LocalFile.fromPath(sut, sut.root()), path -> null)
                 .insert(LocalFile.fromPath(sut, root.resolve("A")))
                 .insert(LocalFile.fromPath(sut, root.resolve("B")))

--- a/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
+++ b/file-backup-local/src/test/java/com/willmolloy/backup/local/LocalStorageTest.java
@@ -65,8 +65,7 @@ class LocalStorageTest {
     // Then
     assertThat(scan)
         .isEqualTo(
-            FileTree.builder()
-                .insert(LocalFile.directoryFiller(sut, ""))
+            FileTree.builder(LocalFile.fromPath(sut, sut.root()), path -> null)
                 .insert(LocalFile.fromPath(sut, root.resolve("A")))
                 .insert(LocalFile.fromPath(sut, root.resolve("B")))
                 .insert(LocalFile.fromPath(sut, root.resolve("C")))

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -105,7 +105,7 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
   }
 
   private void deleteFolder(S3File destFile) {
-    // TODO the list is redundant? We already have this info in the FileTree
+    // TODO the list is redundant? We already have this info in the FileTree (descendants -> leaves)
     ListObjectsV2Request listRequest =
         ListObjectsV2Request.builder()
             .bucket(destination.bucketName())

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -2,6 +2,7 @@ package com.willmolloy.backup.s3;
 
 import static com.willmolloy.backup.util.Md5Helper.md5Base64;
 import static com.willmolloy.backup.util.PathHelper.ensureUnixSeparator;
+import static com.willmolloy.backup.util.StreamHelper.chunk;
 import static java.util.Objects.requireNonNull;
 
 import com.willmolloy.backup.BaseBackup;
@@ -12,6 +13,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -21,12 +23,9 @@ import software.amazon.awssdk.services.s3.model.Delete;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.StorageClass;
-import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
 import software.amazon.awssdk.services.s3.waiters.S3Waiter;
 
 /**
@@ -94,8 +93,10 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
       } else {
         deleteObject(destFile);
       }
-
       log.info("Deleted: [{}]", destFile.uri());
+      return true;
+    } catch (NoSuchFileException e) {
+      log.debug("Already deleted: [{}]", destFile, e);
       return true;
     } catch (Exception e) {
       log.error("Error deleting: [{}]", destFile.uri(), e);
@@ -103,37 +104,29 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
     }
   }
 
-  private void deleteFolder(S3File destFile) {
-    // TODO the list is redundant? We already have this info in the FileTree (subtree -> leaves)
-    ListObjectsV2Request listRequest =
-        ListObjectsV2Request.builder()
-            .bucket(destination.bucketName())
-            .prefix(s3Key(destFile))
-            .build();
-    ListObjectsV2Iterable paginatedListResponse = s3Client.listObjectsV2Paginator(listRequest);
-
-    for (ListObjectsV2Response listResponse : paginatedListResponse) {
-      List<ObjectIdentifier> objects =
-          listResponse.contents().stream()
-              .map(s3Object -> ObjectIdentifier.builder().key(s3Object.key()).build())
-              .toList();
-      if (objects.isEmpty()) {
-        break;
-      }
-      DeleteObjectsRequest deleteRequest =
-          DeleteObjectsRequest.builder()
-              .bucket(destination.bucketName())
-              .delete(Delete.builder().objects(objects).build())
-              .build();
-      s3Client.deleteObjects(deleteRequest);
-    }
+  private void deleteFolder(S3File destFile) throws NoSuchFileException {
+    // TODO cache scan
+    Stream<S3File> filesToDelete = destination.scan().subtree(destFile).leaves();
+    Stream<List<S3File>> chunks = chunk(filesToDelete, 1000);
+    chunks
+        .map(
+            chunk ->
+                chunk.stream()
+                    .map(s3File -> ObjectIdentifier.builder().key(s3Key(s3File)).build())
+                    .toList())
+        .map(
+            objects ->
+                DeleteObjectsRequest.builder()
+                    .bucket(destination.bucketName())
+                    .delete(Delete.builder().objects(objects).build())
+                    .build())
+        .forEach(s3Client::deleteObjects);
   }
 
   private void deleteObject(S3File destFile) {
     DeleteObjectRequest request =
         DeleteObjectRequest.builder().bucket(destination.bucketName()).key(s3Key(destFile)).build();
     s3Client.deleteObject(request);
-
     wait(s3Key(destFile), s3Waiter::waitUntilObjectNotExists);
   }
 
@@ -148,6 +141,7 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
     return file.isDirectory() ? key + "/" : key;
   }
 
+  // TODO this just throws errors - not using it right?
   private void wait(String key, Function<HeadObjectRequest, WaiterResponse<?>> waiter) {
     HeadObjectRequest headRequest =
         HeadObjectRequest.builder().bucket(destination.bucketName()).key(key).build();

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -105,7 +105,7 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
   }
 
   private void deleteFolder(S3File destFile) {
-    // TODO the list is redundant? We already have this info in the FileTree (descendants -> leaves)
+    // TODO the list is redundant? We already have this info in the FileTree (subtree -> leaves)
     ListObjectsV2Request listRequest =
         ListObjectsV2Request.builder()
             .bucket(destination.bucketName())

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -103,7 +103,7 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
 
   private void deleteFolder(S3File destFile) {
     // TODO cache scan
-    Stream<S3File> filesToDelete = destination.scan().subtree(destFile).leaves();
+    Stream<S3File> filesToDelete = destination.fileTree().subtree(destFile).leaves();
     Stream<List<S3File>> chunks = chunk(filesToDelete, 1000);
     chunks
         .map(

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -95,16 +95,13 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
       }
       log.info("Deleted: [{}]", destFile.uri());
       return true;
-    } catch (NoSuchFileException e) {
-      log.debug("Already deleted: [{}]", destFile, e);
-      return true;
     } catch (Exception e) {
       log.error("Error deleting: [{}]", destFile.uri(), e);
       return false;
     }
   }
 
-  private void deleteFolder(S3File destFile) throws NoSuchFileException {
+  private void deleteFolder(S3File destFile) {
     // TODO cache scan
     Stream<S3File> filesToDelete = destination.scan().subtree(destFile).leaves();
     Stream<List<S3File>> chunks = chunk(filesToDelete, 1000);

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -102,7 +102,6 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
   }
 
   private void deleteFolder(S3File destFile) {
-    // TODO cache scan
     Stream<S3File> filesToDelete = destination.fileTree().subtree(destFile).leaves();
     Stream<List<S3File>> chunks = chunk(filesToDelete, 1000);
     chunks

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Backup.java
@@ -8,7 +8,6 @@ import com.willmolloy.backup.BaseBackup;
 import com.willmolloy.backup.File;
 import com.willmolloy.backup.local.LocalFile;
 import com.willmolloy.backup.local.LocalStorage;
-import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
@@ -81,7 +80,7 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
           destinationUri,
           e);
       return true;
-    } catch (RuntimeException | IOException e) {
+    } catch (Exception e) {
       log.error("Error putting: [{}] -> [{}]", sourcePath, destinationUri, e);
       return false;
     }
@@ -98,7 +97,7 @@ final class S3Backup extends BaseBackup<LocalFile, S3File> {
 
       log.info("Deleted: [{}]", destFile.uri());
       return true;
-    } catch (RuntimeException e) {
+    } catch (Exception e) {
       log.error("Error deleting: [{}]", destFile.uri(), e);
       return false;
     }

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Bucket.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Bucket.java
@@ -3,8 +3,8 @@ package com.willmolloy.backup.s3;
 import static com.willmolloy.backup.util.PathHelper.ensureUnixSeparator;
 import static java.util.Objects.requireNonNull;
 
+import com.willmolloy.backup.BaseLocation;
 import com.willmolloy.backup.FileTree;
-import com.willmolloy.backup.Location;
 import java.nio.file.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -19,7 +19,7 @@ import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
  *
  * @author <a href=https://willmolloy.com>Will Molloy</a>
  */
-final class S3Bucket implements Location<S3File> {
+final class S3Bucket extends BaseLocation<S3File> {
 
   private static final Logger log = LogManager.getLogger();
 
@@ -37,7 +37,7 @@ final class S3Bucket implements Location<S3File> {
   }
 
   @Override
-  public FileTree<S3File> scan() {
+  protected FileTree<S3File> scan() {
     log.info("Scanning bucket: [{}]", bucketUri());
     ListObjectsV2Request request =
         ListObjectsV2Request.builder()

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Bucket.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Bucket.java
@@ -38,7 +38,6 @@ final class S3Bucket extends BaseLocation<S3File> {
 
   @Override
   protected FileTree<S3File> scan() {
-    log.info("Scanning bucket: [{}]", bucketUri());
     ListObjectsV2Request request =
         ListObjectsV2Request.builder()
             .bucket(bucketName)

--- a/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Bucket.java
+++ b/file-backup-s3/src/main/java/com/willmolloy/backup/s3/S3Bucket.java
@@ -47,7 +47,8 @@ final class S3Bucket implements Location<S3File> {
     ListObjectsV2Iterable paginatedResponse = s3Client.listObjectsV2Paginator(request);
 
     FileTree.Builder<S3File> builder =
-        FileTree.<S3File>builder().withDirectoryFiller(path -> S3File.directoryFiller(this, path));
+        FileTree.builder(
+            S3File.directoryFiller(this, ""), path -> S3File.directoryFiller(this, path));
     for (ListObjectsV2Response response : paginatedResponse) {
       for (S3Object s3Object : response.contents()) {
         S3File file = S3File.fromS3Object(this, s3Object);

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.Range;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.willmolloy.backup.local.LocalFile;
@@ -21,6 +22,7 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -197,21 +199,30 @@ class S3BackupTest {
   @Test
   void delete_whenFolder_makesDeleteObjectsRequests() {
     // Given
-    S3File destFile = createS3Folder("X/Y/Z/");
+    S3File destFile = createS3Folder("folder/");
 
     ListObjectsV2Response page1 =
-        ListObjectsV2Response.builder().contents(S3Object.builder().key("A").build()).build();
+        ListObjectsV2Response.builder()
+            .contents(S3Object.builder().key("my/bucket/prefix/backups/folder/A").build())
+            .build();
     ListObjectsV2Response page2 =
         ListObjectsV2Response.builder()
-            .contents(S3Object.builder().key("B").build(), S3Object.builder().key("C").build())
+            .contents(
+                S3Object.builder().key("my/bucket/prefix/backups/folder/B").build(),
+                S3Object.builder().key("my/bucket/prefix/backups/folder/C").build())
             .build();
-
+    ListObjectsV2Response page3 =
+        ListObjectsV2Response.builder()
+            .contents(
+                S3Object.builder().key("my/bucket/prefix/backups/folder/D/E").build(),
+                S3Object.builder().key("my/bucket/prefix/backups/folder/D/F/G").build())
+            .build();
     ListObjectsV2Iterable response = mock(ListObjectsV2Iterable.class);
-    when(response.iterator()).thenReturn(List.of(page1, page2).iterator());
+    when(response.iterator()).thenReturn(List.of(page1, page2, page3).iterator());
     when(mockS3Client.listObjectsV2Paginator(
             ListObjectsV2Request.builder()
                 .bucket("my-bucket")
-                .prefix("my/bucket/prefix/backups/X/Y/Z/")
+                .prefix("my/bucket/prefix/backups/")
                 .build()))
         .thenReturn(response);
 
@@ -225,19 +236,91 @@ class S3BackupTest {
             DeleteObjectsRequest.builder()
                 .bucket("my-bucket")
                 .delete(
-                    Delete.builder().objects(ObjectIdentifier.builder().key("A").build()).build())
-                .build());
-    verify(mockS3Client)
-        .deleteObjects(
-            DeleteObjectsRequest.builder()
-                .bucket("my-bucket")
-                .delete(
                     Delete.builder()
                         .objects(
-                            ObjectIdentifier.builder().key("B").build(),
-                            ObjectIdentifier.builder().key("C").build())
+                            ObjectIdentifier.builder()
+                                .key("my/bucket/prefix/backups/folder/A")
+                                .build(),
+                            ObjectIdentifier.builder()
+                                .key("my/bucket/prefix/backups/folder/B")
+                                .build(),
+                            ObjectIdentifier.builder()
+                                .key("my/bucket/prefix/backups/folder/C")
+                                .build(),
+                            ObjectIdentifier.builder()
+                                .key("my/bucket/prefix/backups/folder/D/E")
+                                .build(),
+                            ObjectIdentifier.builder()
+                                .key("my/bucket/prefix/backups/folder/D/F/G")
+                                .build())
                         .build())
                 .build());
+  }
+
+  @Test
+  void delete_whenFolder_makesDeleteObjectsRequests_inChunksOf1000Keys() {
+    // Given
+    S3File destFile = createS3Folder("folder/");
+
+    List<S3Object> s3Objects =
+        IntStream.rangeClosed(0, 2010)
+            .mapToObj(i -> S3Object.builder().key("my/bucket/prefix/backups/folder/" + i).build())
+            .toList();
+    ListObjectsV2Response page = ListObjectsV2Response.builder().contents(s3Objects).build();
+    ListObjectsV2Iterable response = mock(ListObjectsV2Iterable.class);
+    when(response.iterator()).thenReturn(List.of(page).iterator());
+    when(mockS3Client.listObjectsV2Paginator(
+            ListObjectsV2Request.builder()
+                .bucket("my-bucket")
+                .prefix("my/bucket/prefix/backups/")
+                .build()))
+        .thenReturn(response);
+
+    // When
+    boolean result = sut.delete(destFile);
+
+    // Then
+    assertThat(result).isTrue();
+    for (Range<Integer> range :
+        List.of(Range.closed(0, 999), Range.closed(1000, 1999), Range.closed(2000, 2010))) {
+      verify(mockS3Client)
+          .deleteObjects(
+              DeleteObjectsRequest.builder()
+                  .bucket("my-bucket")
+                  .delete(
+                      Delete.builder()
+                          .objects(
+                              IntStream.rangeClosed(range.lowerEndpoint(), range.upperEndpoint())
+                                  .mapToObj(
+                                      i ->
+                                          ObjectIdentifier.builder()
+                                              .key("my/bucket/prefix/backups/folder/" + i)
+                                              .build())
+                                  .toList())
+                          .build())
+                  .build());
+    }
+  }
+
+  @Test
+  void delete_whenFolder_notInTree_failsGracefully() {
+    // Given
+    S3File destFile = createS3Folder("folder/");
+
+    ListObjectsV2Iterable response = mock(ListObjectsV2Iterable.class);
+    when(response.iterator()).thenReturn(List.<ListObjectsV2Response>of().iterator());
+    when(mockS3Client.listObjectsV2Paginator(
+            ListObjectsV2Request.builder()
+                .bucket("my-bucket")
+                .prefix("my/bucket/prefix/backups/")
+                .build()))
+        .thenReturn(response);
+
+    // When
+    boolean result = assertDoesNotThrow(() -> sut.delete(destFile));
+
+    // Then
+    assertThat(result).isTrue();
   }
 
   @Test

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
@@ -303,27 +303,6 @@ class S3BackupTest {
   }
 
   @Test
-  void delete_whenFolder_notInTree_failsGracefully() {
-    // Given
-    S3File destFile = createS3Folder("folder/");
-
-    ListObjectsV2Iterable response = mock(ListObjectsV2Iterable.class);
-    when(response.iterator()).thenReturn(List.<ListObjectsV2Response>of().iterator());
-    when(mockS3Client.listObjectsV2Paginator(
-            ListObjectsV2Request.builder()
-                .bucket("my-bucket")
-                .prefix("my/bucket/prefix/backups/")
-                .build()))
-        .thenReturn(response);
-
-    // When
-    boolean result = assertDoesNotThrow(() -> sut.delete(destFile));
-
-    // Then
-    assertThat(result).isTrue();
-  }
-
-  @Test
   void delete_whenS3Error_failsGracefully() {
     // Given
     S3File destFile = createS3Object("X/Y/Z");

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
@@ -197,7 +197,7 @@ class S3BackupTest {
   }
 
   @Test
-  void delete_whenFolder_makesDeleteObjectsRequests() {
+  void delete_whenFolder_makesDeleteObjectsRequest() {
     // Given
     S3File destFile = createS3Folder("folder/");
 
@@ -258,7 +258,7 @@ class S3BackupTest {
   }
 
   @Test
-  void delete_whenFolder_makesDeleteObjectsRequests_inChunksOf1000Keys() {
+  void delete_whenFolder_makesDeleteObjectsRequestsInChunksOf1000Keys() {
     // Given
     S3File destFile = createS3Folder("folder/");
 

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BackupTest.java
@@ -160,7 +160,6 @@ class S3BackupTest {
   void put_whenS3Error_failsGracefully() throws IOException {
     // Given
     LocalFile sourceFile = createLocalFile(fs.getPath("A/B/C"));
-
     when(mockS3Client.putObject(any(PutObjectRequest.class), any(Path.class)))
         .thenThrow(new RuntimeException());
 

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BucketTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BucketTest.java
@@ -68,8 +68,7 @@ class S3BucketTest {
     // Then
     assertThat(scan)
         .isEqualTo(
-            // null directoryFiller, otherwise it isn't tested!
-            FileTree.builder(S3File.directoryFiller(sut, ""), path -> null)
+            FileTree.builder(S3File.directoryFiller(sut, ""))
                 .insert(S3File.fromS3Object(sut, a))
                 .insert(S3File.fromS3Object(sut, b))
                 .insert(S3File.directoryFiller(sut, "C"))

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BucketTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BucketTest.java
@@ -63,7 +63,7 @@ class S3BucketTest {
     when(mockS3Client.listObjectsV2Paginator(request)).thenReturn(response);
 
     // When
-    FileTree<S3File> scan = sut.scan();
+    FileTree<S3File> scan = sut.fileTree();
 
     // Then
     assertThat(scan)

--- a/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BucketTest.java
+++ b/file-backup-s3/src/test/java/com/willmolloy/backup/s3/S3BucketTest.java
@@ -68,8 +68,8 @@ class S3BucketTest {
     // Then
     assertThat(scan)
         .isEqualTo(
-            FileTree.builder()
-                .insert(S3File.directoryFiller(sut, ""))
+            // null directoryFiller, otherwise it isn't tested!
+            FileTree.builder(S3File.directoryFiller(sut, ""), path -> null)
                 .insert(S3File.fromS3Object(sut, a))
                 .insert(S3File.fromS3Object(sut, b))
                 .insert(S3File.directoryFiller(sut, "C"))


### PR DESCRIPTION
Avoid unnecessary scan when deleting a directory/folder via new `FileTree.subtree` method.
- `LocalBackup` uses `FileTree.subtree.postorder` rather than redundant `Files.walkFileTree`
- `S3Backup` uses `FileTree.subtree.leaves` for the `DeleteObjectsRequest`, avoiding redundant `ListObjects`
- The `Location.fileTree` is now cached to achieve this, `FileTree.subtree` is O(1) (returns a view)
- **This change assumes the destination files are not modified outside the `file-backup` run**

Also general refactoring, improving tests, javadocs, etc.
