### PR TITLE
Separate `S3Client` per request

### DIFF
--- a/file-sync-core/src/main/resources/log4j2.xml
+++ b/file-sync-core/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
 
     <Logger name="com.willmolloy" level="info"/>
 
-    <Logger name="software.amazon.awssdk" level="warn" />
-    <Logger name="software.amazon.awssdk.request" level="debug" />
+    <Logger name="software.amazon.awssdk" level="warn"/>
+    <Logger name="software.amazon.awssdk.request" level="debug"/>
   </Loggers>
 </Configuration>

--- a/file-sync-core/src/main/resources/log4j2.xml
+++ b/file-sync-core/src/main/resources/log4j2.xml
@@ -12,5 +12,8 @@
     </Root>
 
     <Logger name="com.willmolloy" level="info"/>
+
+    <Logger name="software.amazon.awssdk" level="warn" />
+    <Logger name="software.amazon.awssdk.request" level="debug" />
   </Loggers>
 </Configuration>

--- a/file-sync-local/src/main/java/com/willmolloy/sync/local/LocalStorage.java
+++ b/file-sync-local/src/main/java/com/willmolloy/sync/local/LocalStorage.java
@@ -48,6 +48,8 @@ public final class LocalStorage implements Location<LocalFile> {
   @Override
   public FileTree<LocalFile> scan() {
     try {
+      log.debug("Scanning root dir: [{}]", rootDir);
+
       FileTree.Builder<LocalFile> builder =
           FileTree.builder(
               LocalFile.fromPath(this, rootDir), path -> LocalFile.directoryFiller(this, path));

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/Main.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/Main.java
@@ -13,6 +13,8 @@ import java.nio.file.FileSystems;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.waiters.S3Waiter;
@@ -26,33 +28,34 @@ final class Main {
 
   /** Main method. */
   public static void main(String... args) {
-    try (S3Client s3Client =
-            S3Client.builder().region(Region.US_EAST_1).forcePathStyle(true).build();
-        S3Waiter s3Waiter =
+    Supplier<S3Client> s3Client =
+        () -> S3Client.builder().region(Region.US_EAST_1).forcePathStyle(true).build();
+    Function<S3Client, S3Waiter> s3Waiter =
+        (client) ->
             S3Waiter.builder()
-                .client(s3Client)
+                .client(client)
                 .overrideConfiguration(config -> config.waitTimeout(Duration.ofHours(1)))
-                .build()) {
-      String sourcePath = getRequiredEnvVariable("SOURCE_PATH");
-      String destBucket = getRequiredEnvVariable("DESTINATION_BUCKET");
-      String destPrefix = getRequiredEnvVariable("DESTINATION_BUCKET_PREFIX");
+                .build();
 
-      FileSystem fs = FileSystems.getDefault();
+    String sourcePath = getRequiredEnvVariable("SOURCE_PATH");
+    String destBucket = getRequiredEnvVariable("DESTINATION_BUCKET");
+    String destPrefix = getRequiredEnvVariable("DESTINATION_BUCKET_PREFIX");
 
-      LocalStorage source = new LocalStorage(fs.getPath(sourcePath));
-      checkArgument(
-          destPrefix.endsWith("/"), "Requires bucket prefix to end with '/': " + destPrefix);
-      S3Bucket dest = new S3Bucket(s3Client, destBucket, fs.getPath(destPrefix));
+    FileSystem fs = FileSystems.getDefault();
 
-      List<SyncObserver> observers = new ArrayList<>();
-      observers.add(new LoggingSyncObserver());
-      getOptionalEnvVariable("DISCORD_WEBHOOK")
-          .ifPresent(webhookUrl -> observers.add(new DiscordWebhook(webhookUrl)));
+    LocalStorage source = new LocalStorage(fs.getPath(sourcePath));
+    checkArgument(
+        destPrefix.endsWith("/"), "Requires bucket prefix to end with '/': " + destPrefix);
+    S3Bucket dest = new S3Bucket(s3Client, destBucket, fs.getPath(destPrefix));
 
-      S3Sync s3Sync = new S3Sync(s3Client, s3Waiter, source, dest, observers);
-      if (!s3Sync.run()) {
-        System.exit(1);
-      }
+    List<SyncObserver> observers = new ArrayList<>();
+    observers.add(new LoggingSyncObserver());
+    getOptionalEnvVariable("DISCORD_WEBHOOK")
+        .ifPresent(webhookUrl -> observers.add(new DiscordWebhook(webhookUrl)));
+
+    S3Sync s3Sync = new S3Sync(s3Client, s3Waiter, source, dest, observers);
+    if (!s3Sync.run()) {
+      System.exit(1);
     }
   }
 

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Bucket.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Bucket.java
@@ -40,6 +40,7 @@ final class S3Bucket implements Location<S3File> {
   @Override
   public FileTree<S3File> scan() {
     try (S3Client s3Client = s3ClientSupplier.get()) {
+
       ListObjectsV2Request request =
           ListObjectsV2Request.builder()
               .bucket(bucketName)

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Bucket.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Bucket.java
@@ -6,6 +6,7 @@ import static com.willmolloy.sync.util.PathHelper.ensureUnixSeparator;
 import com.willmolloy.sync.FileTree;
 import com.willmolloy.sync.Location;
 import java.nio.file.Path;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -25,36 +26,38 @@ final class S3Bucket implements Location<S3File> {
 
   private static final String S3_BASE_URI = "https://s3.console.aws.amazon.com/s3/";
 
-  private final S3Client s3Client;
+  private final Supplier<S3Client> s3ClientSupplier;
 
   private final String bucketName;
   private final Path prefix;
 
-  S3Bucket(S3Client s3Client, String bucketName, Path prefix) {
-    this.s3Client = checkNotNull(s3Client);
+  S3Bucket(Supplier<S3Client> s3ClientSupplier, String bucketName, Path prefix) {
+    this.s3ClientSupplier = checkNotNull(s3ClientSupplier);
     this.bucketName = checkNotNull(bucketName);
     this.prefix = checkNotNull(prefix);
   }
 
   @Override
   public FileTree<S3File> scan() {
-    ListObjectsV2Request request =
-        ListObjectsV2Request.builder()
-            .bucket(bucketName)
-            .prefix(ensureUnixSeparator(prefix) + "/")
-            .build();
-    ListObjectsV2Iterable paginatedResponse = s3Client.listObjectsV2Paginator(request);
+    try (S3Client s3Client = s3ClientSupplier.get()) {
+      ListObjectsV2Request request =
+          ListObjectsV2Request.builder()
+              .bucket(bucketName)
+              .prefix(ensureUnixSeparator(prefix) + "/")
+              .build();
+      ListObjectsV2Iterable paginatedResponse = s3Client.listObjectsV2Paginator(request);
 
-    FileTree.Builder<S3File> builder =
-        FileTree.builder(
-            S3File.directoryFiller(this, ""), path -> S3File.directoryFiller(this, path));
-    for (ListObjectsV2Response response : paginatedResponse) {
-      for (S3Object s3Object : response.contents()) {
-        S3File file = S3File.fromS3Object(this, s3Object);
-        builder.insert(file);
+      FileTree.Builder<S3File> builder =
+          FileTree.builder(
+              S3File.directoryFiller(this, ""), path -> S3File.directoryFiller(this, path));
+      for (ListObjectsV2Response response : paginatedResponse) {
+        for (S3Object s3Object : response.contents()) {
+          S3File file = S3File.fromS3Object(this, s3Object);
+          builder.insert(file);
+        }
       }
+      return builder.build();
     }
-    return builder.build();
   }
 
   String bucketName() {

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Bucket.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Bucket.java
@@ -26,21 +26,21 @@ final class S3Bucket implements Location<S3File> {
 
   private static final String S3_BASE_URI = "https://s3.console.aws.amazon.com/s3/";
 
-  private final Supplier<S3Client> s3ClientSupplier;
-
+  private final Supplier<S3Client> s3ClientFactory;
   private final String bucketName;
   private final Path prefix;
 
-  S3Bucket(Supplier<S3Client> s3ClientSupplier, String bucketName, Path prefix) {
-    this.s3ClientSupplier = checkNotNull(s3ClientSupplier);
+  S3Bucket(Supplier<S3Client> s3ClientFactory, String bucketName, Path prefix) {
+    this.s3ClientFactory = checkNotNull(s3ClientFactory);
     this.bucketName = checkNotNull(bucketName);
     this.prefix = checkNotNull(prefix);
   }
 
   @Override
   public FileTree<S3File> scan() {
-    try (S3Client s3Client = s3ClientSupplier.get()) {
+    try (S3Client s3Client = s3ClientFactory.get()) {
 
+      log.debug("Sending list request: [{}]", bucketUri());
       ListObjectsV2Request request =
           ListObjectsV2Request.builder()
               .bucket(bucketName)

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
@@ -59,8 +59,10 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
   protected boolean put(LocalFile sourceFile) {
     Path sourcePath = sourceFile.fullPath();
     String destinationUri = s3Uri(sourceFile);
+
     try (S3Client s3Client = s3ClientSupplier.get();
         S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
+
       log.debug("Sending put request: [{}] -> [{}]", sourceFile, destinationUri);
       PutObjectRequest.Builder baseRequest =
           PutObjectRequest.builder()
@@ -75,7 +77,9 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
         PutObjectRequest request = baseRequest.contentMD5(md5Base64(sourcePath)).build();
         s3Client.putObject(request, sourcePath);
       }
+
       wait(s3Key(sourceFile), s3Waiter::waitUntilObjectExists);
+
       log.debug("Sent put request: [{}] -> [{}]", sourceFile, destinationUri);
       return true;
     } catch (NoSuchFileException e) {
@@ -95,12 +99,14 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
   protected boolean delete(FileTree<S3File> destSubtree) {
     try (S3Client s3Client = s3ClientSupplier.get();
         S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
+
       log.debug("Sending delete request: [{}]", destSubtree.root().uri());
       if (destSubtree.root().isDirectory()) {
         deleteFolder(s3Client, s3Waiter, destSubtree);
       } else {
         deleteObject(s3Client, s3Waiter, destSubtree.root());
       }
+
       log.debug("Sent delete request: [{}]", destSubtree.root().uri());
       return true;
     } catch (Exception e) {

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
@@ -5,7 +5,6 @@ import static com.willmolloy.sync.util.Md5Helper.md5Base64;
 import static com.willmolloy.sync.util.PathHelper.ensureUnixSeparator;
 import static com.willmolloy.sync.util.StreamHelper.chunk;
 
-import com.google.common.collect.Lists;
 import com.willmolloy.sync.BaseSync;
 import com.willmolloy.sync.File;
 import com.willmolloy.sync.FileTree;
@@ -63,11 +62,10 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
     try (S3Client s3Client = s3ClientSupplier.get();
         S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
       log.debug("Sending put request: [{}] -> [{}]", sourceFile, destinationUri);
-      String key = s3Key(sourceFile);
       PutObjectRequest.Builder baseRequest =
           PutObjectRequest.builder()
               .bucket(destination.bucketName())
-              .key(key)
+              .key(s3Key(sourceFile))
               .storageClass(StorageClass.DEEP_ARCHIVE);
       if (sourceFile.isDirectory()) {
         PutObjectRequest request = baseRequest.build();
@@ -77,7 +75,7 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
         PutObjectRequest request = baseRequest.contentMD5(md5Base64(sourcePath)).build();
         s3Client.putObject(request, sourcePath);
       }
-      wait(key, s3Waiter::waitUntilObjectExists);
+      wait(s3Key(sourceFile), s3Waiter::waitUntilObjectExists);
       log.debug("Sent put request: [{}] -> [{}]", sourceFile, destinationUri);
       return true;
     } catch (NoSuchFileException e) {
@@ -112,30 +110,31 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
   }
 
   private void deleteFolder(S3Client s3Client, S3Waiter s3Waiter, FileTree<S3File> destSubtree) {
-    List<String> keys = destSubtree.leaves().map(this::s3Key).toList();
+    // only send delete request for objects
+    chunk(destSubtree.leaves().map(this::s3Key), 1000)
+        .map(
+            chunk ->
+                chunk.stream().map(key -> ObjectIdentifier.builder().key(key).build()).toList())
+        .map(
+            objects ->
+                DeleteObjectsRequest.builder()
+                    .bucket(destination.bucketName())
+                    .delete(Delete.builder().objects(objects).build())
+                    .build())
+        .forEach(s3Client::deleteObjects);
 
-    for (List<String> chunk : Lists.partition(keys, 1000)) {
-      List<ObjectIdentifier> objects =
-          chunk.stream().map(key -> ObjectIdentifier.builder().key(key).build()).toList();
-      DeleteObjectsRequest request =
-          DeleteObjectsRequest.builder()
-              .bucket(destination.bucketName())
-              .delete(Delete.builder().objects(objects).build())
-              .build();
-      s3Client.deleteObjects(request);
-    }
-
-    for (String key : keys) {
-      wait(key, s3Waiter::waitUntilObjectNotExists);
-    }
+    // wait on objects AND folders to be sure
+    destSubtree
+        .postorder()
+        .map(this::s3Key)
+        .forEach(key -> wait(key, s3Waiter::waitUntilObjectNotExists));
   }
 
   private void deleteObject(S3Client s3Client, S3Waiter s3Waiter, S3File destFile) {
-    String key = s3Key(destFile);
     DeleteObjectRequest request =
-        DeleteObjectRequest.builder().bucket(destination.bucketName()).key(key).build();
+        DeleteObjectRequest.builder().bucket(destination.bucketName()).key(s3Key(destFile)).build();
     s3Client.deleteObject(request);
-    wait(key, s3Waiter::waitUntilObjectNotExists);
+    wait(s3Key(destFile), s3Waiter::waitUntilObjectNotExists);
   }
 
   private String s3Uri(File file) {
@@ -149,12 +148,11 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
     return file.isDirectory() ? key + "/" : key;
   }
 
-  private void wait(
-      String key, java.util.function.Function<HeadObjectRequest, WaiterResponse<?>> waiter) {
+  private void wait(String key, Function<HeadObjectRequest, WaiterResponse<?>> waiter) {
     HeadObjectRequest headRequest =
         HeadObjectRequest.builder().bucket(destination.bucketName()).key(key).build();
-    // we are supposed to ignore the ResponseOrException here?
-    // only populated when successful (even the Exception e.g. 404 for waitUntilObjectNotExists)
+    // ignore the ResponseOrException here, it's only populated when successful
+    // (even the exception - e.g. 404 is expected for waitUntilObjectNotExists)
     // the method call itself will throw an exception if something went wrong.
     // https://github.com/aws/aws-sdk-java-v2/issues/2460#issuecomment-837136429
     waiter.apply(headRequest);

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
@@ -39,19 +39,19 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
 
   private static final Logger log = LogManager.getLogger();
 
-  private final Supplier<S3Client> s3ClientSupplier;
-  private final Function<S3Client, S3Waiter> s3WaiterSupplier;
+  private final Supplier<S3Client> s3ClientFactory;
+  private final Function<S3Client, S3Waiter> s3WaiterFactory;
   private final S3Bucket destination;
 
   S3Sync(
-      Supplier<S3Client> s3ClientSupplier,
-      Function<S3Client, S3Waiter> s3WaiterSupplier,
+      Supplier<S3Client> s3ClientFactory,
+      Function<S3Client, S3Waiter> s3WaiterFactory,
       LocalStorage source,
       S3Bucket destination,
       List<SyncObserver> observers) {
     super(source, destination, observers);
-    this.s3ClientSupplier = checkNotNull(s3ClientSupplier);
-    this.s3WaiterSupplier = checkNotNull(s3WaiterSupplier);
+    this.s3ClientFactory = checkNotNull(s3ClientFactory);
+    this.s3WaiterFactory = checkNotNull(s3WaiterFactory);
     this.destination = checkNotNull(destination);
   }
 
@@ -60,8 +60,8 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
     Path sourcePath = sourceFile.fullPath();
     String destinationUri = s3Uri(sourceFile);
 
-    try (S3Client s3Client = s3ClientSupplier.get();
-        S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
+    try (S3Client s3Client = s3ClientFactory.get();
+        S3Waiter s3Waiter = s3WaiterFactory.apply(s3Client)) {
 
       log.debug("Sending put request: [{}] -> [{}]", sourceFile, destinationUri);
       PutObjectRequest.Builder baseRequest =
@@ -97,8 +97,8 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
 
   @Override
   protected boolean delete(FileTree<S3File> destSubtree) {
-    try (S3Client s3Client = s3ClientSupplier.get();
-        S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
+    try (S3Client s3Client = s3ClientFactory.get();
+        S3Waiter s3Waiter = s3WaiterFactory.apply(s3Client)) {
 
       log.debug("Sending delete request: [{}]", destSubtree.root().uri());
       if (destSubtree.root().isDirectory()) {

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
@@ -5,6 +5,7 @@ import static com.willmolloy.sync.util.Md5Helper.md5Base64;
 import static com.willmolloy.sync.util.PathHelper.ensureUnixSeparator;
 import static com.willmolloy.sync.util.StreamHelper.chunk;
 
+import com.google.common.collect.Lists;
 import com.willmolloy.sync.BaseSync;
 import com.willmolloy.sync.File;
 import com.willmolloy.sync.FileTree;
@@ -16,7 +17,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -63,10 +63,11 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
     try (S3Client s3Client = s3ClientSupplier.get();
         S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
       log.debug("Sending put request: [{}] -> [{}]", sourceFile, destinationUri);
+      String key = s3Key(sourceFile);
       PutObjectRequest.Builder baseRequest =
           PutObjectRequest.builder()
               .bucket(destination.bucketName())
-              .key(s3Key(sourceFile))
+              .key(key)
               .storageClass(StorageClass.DEEP_ARCHIVE);
       if (sourceFile.isDirectory()) {
         PutObjectRequest request = baseRequest.build();
@@ -76,7 +77,7 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
         PutObjectRequest request = baseRequest.contentMD5(md5Base64(sourcePath)).build();
         s3Client.putObject(request, sourcePath);
       }
-      wait(s3Key(sourceFile), s3Waiter::waitUntilObjectExists);
+      wait(key, s3Waiter::waitUntilObjectExists);
       log.debug("Sent put request: [{}] -> [{}]", sourceFile, destinationUri);
       return true;
     } catch (NoSuchFileException e) {
@@ -98,7 +99,7 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
         S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
       log.debug("Sending delete request: [{}]", destSubtree.root().uri());
       if (destSubtree.root().isDirectory()) {
-        deleteFolder(s3Client, destSubtree);
+        deleteFolder(s3Client, s3Waiter, destSubtree);
       } else {
         deleteObject(s3Client, s3Waiter, destSubtree.root());
       }
@@ -110,29 +111,31 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
     }
   }
 
-  private void deleteFolder(S3Client s3Client, FileTree<S3File> destSubtree) {
-    Stream<S3File> filesToDelete = destSubtree.leaves();
-    Stream<List<S3File>> chunks = chunk(filesToDelete, 1000);
-    chunks
-        .map(
-            chunk ->
-                chunk.stream()
-                    .map(s3File -> ObjectIdentifier.builder().key(s3Key(s3File)).build())
-                    .toList())
-        .map(
-            objects ->
-                DeleteObjectsRequest.builder()
-                    .bucket(destination.bucketName())
-                    .delete(Delete.builder().objects(objects).build())
-                    .build())
-        .forEach(s3Client::deleteObjects);
+  private void deleteFolder(S3Client s3Client, S3Waiter s3Waiter, FileTree<S3File> destSubtree) {
+    List<String> keys = destSubtree.leaves().map(this::s3Key).toList();
+
+    for (List<String> chunk : Lists.partition(keys, 1000)) {
+      List<ObjectIdentifier> objects =
+          chunk.stream().map(key -> ObjectIdentifier.builder().key(key).build()).toList();
+      DeleteObjectsRequest request =
+          DeleteObjectsRequest.builder()
+              .bucket(destination.bucketName())
+              .delete(Delete.builder().objects(objects).build())
+              .build();
+      s3Client.deleteObjects(request);
+    }
+
+    for (String key : keys) {
+      wait(key, s3Waiter::waitUntilObjectNotExists);
+    }
   }
 
   private void deleteObject(S3Client s3Client, S3Waiter s3Waiter, S3File destFile) {
+    String key = s3Key(destFile);
     DeleteObjectRequest request =
-        DeleteObjectRequest.builder().bucket(destination.bucketName()).key(s3Key(destFile)).build();
+        DeleteObjectRequest.builder().bucket(destination.bucketName()).key(key).build();
     s3Client.deleteObject(request);
-    wait(s3Key(destFile), s3Waiter::waitUntilObjectNotExists);
+    wait(key, s3Waiter::waitUntilObjectNotExists);
   }
 
   private String s3Uri(File file) {

--- a/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
+++ b/file-sync-s3/src/main/java/com/willmolloy/sync/s3/S3Sync.java
@@ -14,7 +14,8 @@ import com.willmolloy.sync.statistics.SyncObserver;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -39,19 +40,19 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
 
   private static final Logger log = LogManager.getLogger();
 
-  private final S3Client s3Client;
-  private final S3Waiter s3Waiter;
+  private final Supplier<S3Client> s3ClientSupplier;
+  private final Function<S3Client, S3Waiter> s3WaiterSupplier;
   private final S3Bucket destination;
 
   S3Sync(
-      S3Client s3Client,
-      S3Waiter s3Waiter,
+      Supplier<S3Client> s3ClientSupplier,
+      Function<S3Client, S3Waiter> s3WaiterSupplier,
       LocalStorage source,
       S3Bucket destination,
       List<SyncObserver> observers) {
     super(source, destination, observers);
-    this.s3Client = checkNotNull(s3Client);
-    this.s3Waiter = checkNotNull(s3Waiter);
+    this.s3ClientSupplier = checkNotNull(s3ClientSupplier);
+    this.s3WaiterSupplier = checkNotNull(s3WaiterSupplier);
     this.destination = checkNotNull(destination);
   }
 
@@ -59,7 +60,8 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
   protected boolean put(LocalFile sourceFile) {
     Path sourcePath = sourceFile.fullPath();
     String destinationUri = s3Uri(sourceFile);
-    try {
+    try (S3Client s3Client = s3ClientSupplier.get();
+        S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
       log.debug("Sending put request: [{}] -> [{}]", sourceFile, destinationUri);
       PutObjectRequest.Builder baseRequest =
           PutObjectRequest.builder()
@@ -74,7 +76,7 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
         PutObjectRequest request = baseRequest.contentMD5(md5Base64(sourcePath)).build();
         s3Client.putObject(request, sourcePath);
       }
-      wait(s3Key(sourceFile), S3Waiter::waitUntilObjectExists);
+      wait(s3Key(sourceFile), s3Waiter::waitUntilObjectExists);
       log.debug("Sent put request: [{}] -> [{}]", sourceFile, destinationUri);
       return true;
     } catch (NoSuchFileException e) {
@@ -92,12 +94,13 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
 
   @Override
   protected boolean delete(FileTree<S3File> destSubtree) {
-    try {
+    try (S3Client s3Client = s3ClientSupplier.get();
+        S3Waiter s3Waiter = s3WaiterSupplier.apply(s3Client)) {
       log.debug("Sending delete request: [{}]", destSubtree.root().uri());
       if (destSubtree.root().isDirectory()) {
-        deleteFolder(destSubtree);
+        deleteFolder(s3Client, destSubtree);
       } else {
-        deleteObject(destSubtree.root());
+        deleteObject(s3Client, s3Waiter, destSubtree.root());
       }
       log.debug("Sent delete request: [{}]", destSubtree.root().uri());
       return true;
@@ -107,7 +110,7 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
     }
   }
 
-  private void deleteFolder(FileTree<S3File> destSubtree) {
+  private void deleteFolder(S3Client s3Client, FileTree<S3File> destSubtree) {
     Stream<S3File> filesToDelete = destSubtree.leaves();
     Stream<List<S3File>> chunks = chunk(filesToDelete, 1000);
     chunks
@@ -125,11 +128,11 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
         .forEach(s3Client::deleteObjects);
   }
 
-  private void deleteObject(S3File destFile) {
+  private void deleteObject(S3Client s3Client, S3Waiter s3Waiter, S3File destFile) {
     DeleteObjectRequest request =
         DeleteObjectRequest.builder().bucket(destination.bucketName()).key(s3Key(destFile)).build();
     s3Client.deleteObject(request);
-    wait(s3Key(destFile), S3Waiter::waitUntilObjectNotExists);
+    wait(s3Key(destFile), s3Waiter::waitUntilObjectNotExists);
   }
 
   private String s3Uri(File file) {
@@ -143,13 +146,14 @@ final class S3Sync extends BaseSync<LocalFile, S3File> {
     return file.isDirectory() ? key + "/" : key;
   }
 
-  private void wait(String key, BiFunction<S3Waiter, HeadObjectRequest, WaiterResponse<?>> waiter) {
+  private void wait(
+      String key, java.util.function.Function<HeadObjectRequest, WaiterResponse<?>> waiter) {
     HeadObjectRequest headRequest =
         HeadObjectRequest.builder().bucket(destination.bucketName()).key(key).build();
     // we are supposed to ignore the ResponseOrException here?
     // only populated when successful (even the Exception e.g. 404 for waitUntilObjectNotExists)
     // the method call itself will throw an exception if something went wrong.
     // https://github.com/aws/aws-sdk-java-v2/issues/2460#issuecomment-837136429
-    waiter.apply(s3Waiter, headRequest);
+    waiter.apply(headRequest);
   }
 }

--- a/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3BucketTest.java
+++ b/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3BucketTest.java
@@ -2,6 +2,7 @@ package com.willmolloy.sync.s3;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -35,7 +36,7 @@ class S3BucketTest {
 
   @BeforeEach
   void setUp() {
-    sut = new S3Bucket(mockS3Client, "my-bucket", Path.of("my/bucket/prefix/"));
+    sut = new S3Bucket(() -> mockS3Client, "my-bucket", Path.of("my/bucket/prefix/"));
   }
 
   @AfterEach
@@ -79,6 +80,7 @@ class S3BucketTest {
                 .insert(S3File.directoryFiller(sut, "X/Y"))
                 .insert(S3File.fromS3Object(sut, z))
                 .build());
+    verify(mockS3Client).close();
   }
 
   @Test

--- a/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3FileTest.java
+++ b/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3FileTest.java
@@ -33,7 +33,7 @@ class S3FileTest {
 
   @BeforeEach
   void setUp() {
-    bucket = new S3Bucket(mockS3Client, "my-bucket", Path.of("prefix"));
+    bucket = new S3Bucket(() -> mockS3Client, "my-bucket", Path.of("prefix"));
   }
 
   @AfterEach

--- a/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3SyncTest.java
+++ b/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3SyncTest.java
@@ -219,6 +219,36 @@ class S3SyncTest {
                             ObjectIdentifier.builder().key("my/bucket/prefix/folder/D/F/G").build())
                         .build())
                 .build());
+    verify(mockS3Waiter)
+        .waitUntilObjectNotExists(
+            HeadObjectRequest.builder()
+                .bucket("my-bucket")
+                .key("my/bucket/prefix/folder/A")
+                .build());
+    verify(mockS3Waiter)
+        .waitUntilObjectNotExists(
+            HeadObjectRequest.builder()
+                .bucket("my-bucket")
+                .key("my/bucket/prefix/folder/B")
+                .build());
+    verify(mockS3Waiter)
+        .waitUntilObjectNotExists(
+            HeadObjectRequest.builder()
+                .bucket("my-bucket")
+                .key("my/bucket/prefix/folder/C")
+                .build());
+    verify(mockS3Waiter)
+        .waitUntilObjectNotExists(
+            HeadObjectRequest.builder()
+                .bucket("my-bucket")
+                .key("my/bucket/prefix/folder/D/E")
+                .build());
+    verify(mockS3Waiter)
+        .waitUntilObjectNotExists(
+            HeadObjectRequest.builder()
+                .bucket("my-bucket")
+                .key("my/bucket/prefix/folder/D/F/G")
+                .build());
     verify(mockS3Client, times(2)).close();
     verify(mockS3Waiter).close();
   }
@@ -236,6 +266,7 @@ class S3SyncTest {
     assertThat(result).isTrue();
     verify(mockS3Client, times(2)).deleteObjects(argThat(deleteRequestSize(1000)));
     verify(mockS3Client).deleteObjects(argThat(deleteRequestSize(11)));
+    verify(mockS3Waiter, times(2011)).waitUntilObjectNotExists(any(HeadObjectRequest.class));
     verify(mockS3Client, times(2)).close();
     verify(mockS3Waiter).close();
   }

--- a/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3SyncTest.java
+++ b/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3SyncTest.java
@@ -241,13 +241,31 @@ class S3SyncTest {
         .waitUntilObjectNotExists(
             HeadObjectRequest.builder()
                 .bucket("my-bucket")
+                .key("my/bucket/prefix/folder/D/")
+                .build());
+    verify(mockS3Waiter)
+        .waitUntilObjectNotExists(
+            HeadObjectRequest.builder()
+                .bucket("my-bucket")
                 .key("my/bucket/prefix/folder/D/E")
                 .build());
     verify(mockS3Waiter)
         .waitUntilObjectNotExists(
             HeadObjectRequest.builder()
                 .bucket("my-bucket")
+                .key("my/bucket/prefix/folder/D/F/")
+                .build());
+    verify(mockS3Waiter)
+        .waitUntilObjectNotExists(
+            HeadObjectRequest.builder()
+                .bucket("my-bucket")
                 .key("my/bucket/prefix/folder/D/F/G")
+                .build());
+    verify(mockS3Waiter)
+        .waitUntilObjectNotExists(
+            HeadObjectRequest.builder()
+                .bucket("my-bucket")
+                .key("my/bucket/prefix/folder/")
                 .build());
     verify(mockS3Client, times(2)).close();
     verify(mockS3Waiter).close();
@@ -266,7 +284,7 @@ class S3SyncTest {
     assertThat(result).isTrue();
     verify(mockS3Client, times(2)).deleteObjects(argThat(deleteRequestSize(1000)));
     verify(mockS3Client).deleteObjects(argThat(deleteRequestSize(11)));
-    verify(mockS3Waiter, times(2011)).waitUntilObjectNotExists(any(HeadObjectRequest.class));
+    verify(mockS3Waiter, times(2012)).waitUntilObjectNotExists(any(HeadObjectRequest.class));
     verify(mockS3Client, times(2)).close();
     verify(mockS3Waiter).close();
   }

--- a/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3SyncTest.java
+++ b/file-sync-s3/src/test/java/com/willmolloy/sync/s3/S3SyncTest.java
@@ -72,10 +72,14 @@ class S3SyncTest {
     Path sourceRoot = fs.getPath("root");
     Files.createDirectory(sourceRoot);
     source = new LocalStorage(sourceRoot);
-    destination = new S3Bucket(mockS3Client, "my-bucket", fs.getPath("my/bucket/prefix/"));
+    destination = new S3Bucket(() -> mockS3Client, "my-bucket", fs.getPath("my/bucket/prefix/"));
     sut =
         new S3Sync(
-            mockS3Client, mockS3Waiter, source, destination, List.of(new LoggingSyncObserver()));
+            () -> mockS3Client,
+            (client) -> mockS3Waiter,
+            source,
+            destination,
+            List.of(new LoggingSyncObserver()));
   }
 
   @AfterEach
@@ -107,6 +111,8 @@ class S3SyncTest {
     verify(mockS3Waiter)
         .waitUntilObjectExists(
             HeadObjectRequest.builder().bucket("my-bucket").key("my/bucket/prefix/A/B/C").build());
+    verify(mockS3Client).close();
+    verify(mockS3Waiter).close();
   }
 
   @Test
@@ -131,6 +137,8 @@ class S3SyncTest {
     verify(mockS3Waiter)
         .waitUntilObjectExists(
             HeadObjectRequest.builder().bucket("my-bucket").key("my/bucket/prefix/A/B/C/").build());
+    verify(mockS3Client).close();
+    verify(mockS3Waiter).close();
   }
 
   @Test
@@ -144,6 +152,8 @@ class S3SyncTest {
 
     // Then
     assertThat(result).isTrue();
+    verify(mockS3Client).close();
+    verify(mockS3Waiter).close();
   }
 
   @Test
@@ -158,6 +168,8 @@ class S3SyncTest {
 
     // Then
     assertThat(result).isFalse();
+    verify(mockS3Client).close();
+    verify(mockS3Waiter).close();
   }
 
   @Test
@@ -179,6 +191,8 @@ class S3SyncTest {
     verify(mockS3Waiter)
         .waitUntilObjectNotExists(
             HeadObjectRequest.builder().bucket("my-bucket").key("my/bucket/prefix/X/Y/Z").build());
+    verify(mockS3Client, times(2)).close();
+    verify(mockS3Waiter).close();
   }
 
   @Test
@@ -205,6 +219,8 @@ class S3SyncTest {
                             ObjectIdentifier.builder().key("my/bucket/prefix/folder/D/F/G").build())
                         .build())
                 .build());
+    verify(mockS3Client, times(2)).close();
+    verify(mockS3Waiter).close();
   }
 
   @Test
@@ -220,6 +236,8 @@ class S3SyncTest {
     assertThat(result).isTrue();
     verify(mockS3Client, times(2)).deleteObjects(argThat(deleteRequestSize(1000)));
     verify(mockS3Client).deleteObjects(argThat(deleteRequestSize(11)));
+    verify(mockS3Client, times(2)).close();
+    verify(mockS3Waiter).close();
   }
 
   @Test
@@ -234,6 +252,8 @@ class S3SyncTest {
 
     // Then
     assertThat(result).isFalse();
+    verify(mockS3Client, times(2)).close();
+    verify(mockS3Waiter).close();
   }
 
   @Test


### PR DESCRIPTION
Fixes error: `software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: Timeout waiting for connection from pool`
- Seems to be caused by too many concurrent requests.

Not sure how to get pool size in order to throttle accordingly, so changed to `S3Client` per request which seems to solve the issue.

Also added `S3Waiter` after folder deleted.